### PR TITLE
Add time zone support to DateTimeInput components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.10.1] - 2026-06-15
+
+### Added
+- `timeZone` and `is24HourFormat` to the `LocaleProvider`/`LocaleContext` (default 24 hour format), used by the date and time inputs, pickers, `TimeDisplay`, `DateProperty` and `useUpdatingDateString`, with optional per-component overrides
+- `DateUtils.toZonedDate`, `DateUtils.fromZonedDate` and `DateUtils.zonedParts`
+
+### Changed
+- `DateProperty` now forwards the full `DateTimeInput` event API (`Date | null` values, `onEditComplete`, `timeZone`, `is24HourFormat`, ranges, ...)
+
+### Fixed
+- Typing a full year (e.g. `2004`) into `DateTimeInput`/`FlexibleDateTimeInput` no longer resets to a 1900s year
+- Date and time segments no longer fire `onEditComplete` while focus auto-advances between segments
+
 ## [0.10.0] - 2026-06-15
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@helpwave/hightide",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@helpwave/hightide",
-      "version": "0.10.0",
+      "version": "0.10.1",
       "license": "MPL-2.0",
       "dependencies": {
         "@helpwave/internationalization": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "access": "public"
   },
   "license": "MPL-2.0",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "files": [
     "dist"
   ],

--- a/src/components/user-interaction/date/TimeDisplay.tsx
+++ b/src/components/user-interaction/date/TimeDisplay.tsx
@@ -1,21 +1,31 @@
 import { useHightideTranslation } from '@/src/i18n/useHightideTranslation'
+import { useDateTimeFormat, useLocale } from '@/src/global-contexts/LocaleContext'
+import { DateUtils } from '@/src/utils/date'
 
 type TimeDisplayMode = 'daysFromToday' | 'date'
 
 type TimeDisplayProps = {
   date: Date,
   mode?: TimeDisplayMode,
+  is24HourFormat?: boolean,
+  timeZone?: string,
 }
 
-/**
- * A Component for displaying time and dates in a unified fashion
- */
 export const TimeDisplay = ({
   date,
-  mode = 'daysFromToday'
+  mode = 'daysFromToday',
+  is24HourFormat: is24HourFormatOverride,
+  timeZone: timeZoneOverride,
 }: TimeDisplayProps) => {
   const translation = useHightideTranslation()
-  const difference = new Date().setHours(0, 0, 0, 0).valueOf() - new Date(date).setHours(0, 0, 0, 0).valueOf()
+  const { locale } = useLocale()
+  const { is24HourFormat: contextIs24HourFormat, timeZone: contextTimeZone } = useDateTimeFormat()
+  const is24HourFormat = is24HourFormatOverride ?? contextIs24HourFormat
+  const timeZone = timeZoneOverride ?? contextTimeZone
+
+  const zonedDate = DateUtils.toZonedDate(date, timeZone)
+  const zonedNow = DateUtils.toZonedDate(new Date(), timeZone)
+  const difference = new Date(zonedNow).setHours(0, 0, 0, 0).valueOf() - new Date(zonedDate).setHours(0, 0, 0, 0).valueOf()
   const isBefore = difference > 0
   const differenceInDays = Math.floor(Math.abs(difference) / (1000 * 3600 * 24))
 
@@ -44,9 +54,15 @@ export const TimeDisplay = ({
 
   let fullString
   if (mode === 'daysFromToday') {
-    fullString = `${date.getHours().toString().padStart(2, '0')}:${date.getMinutes().toString().padStart(2, '0')} - ${displayString}`
+    const timeString = new Intl.DateTimeFormat(locale, {
+      hour: '2-digit',
+      minute: '2-digit',
+      hourCycle: is24HourFormat ? 'h23' : 'h12',
+      timeZone,
+    }).format(date)
+    fullString = `${timeString} - ${displayString}`
   } else {
-    fullString = `${date.getDate()}. ${monthToTranslation[date.getMonth()]} ${date.getFullYear()}`
+    fullString = `${zonedDate.getDate()}. ${monthToTranslation[zonedDate.getMonth()]} ${zonedDate.getFullYear()}`
   }
 
   return (<span>{fullString}</span>)

--- a/src/components/user-interaction/date/TimePicker.tsx
+++ b/src/components/user-interaction/date/TimePicker.tsx
@@ -5,6 +5,7 @@ import type { FormFieldDataHandling } from '@/src/components/form/FormField'
 import { useControlledState } from '@/src/hooks/useControlledState'
 import type { DateTimePrecision } from '@/src/utils/date'
 import { Visibility } from '@/src/components/layout/Visibility'
+import { useDateTimeFormat } from '@/src/global-contexts/LocaleContext'
 
 export type TimePickerMinuteIncrement = '1min' | '5min' | '10min' | '15min' | '30min'
 
@@ -12,7 +13,6 @@ export type TimePickerSecondIncrement = '1s' | '5s' | '10s' | '15s' | '30s'
 
 export type TimePickerMillisecondIncrement = '1ms' | '5ms' | '10ms' | '25ms' | '50ms' | '100ms' | '250ms' | '500ms'
 
-// TODO add start, and end constraints
 export interface TimePickerProps extends Partial<FormFieldDataHandling<Date>> {
   initialValue?: Date,
   is24HourFormat?: boolean,
@@ -28,13 +28,15 @@ export const TimePicker = ({
   initialValue = new Date(),
   onValueChange,
   onEditComplete,
-  is24HourFormat = true,
+  is24HourFormat: is24HourFormatOverride,
   minuteIncrement = '5min',
   secondIncrement = '5s',
   millisecondIncrement = '100ms',
   precision = 'minute',
   className,
 }: TimePickerProps) => {
+  const { is24HourFormat: contextIs24HourFormat } = useDateTimeFormat()
+  const is24HourFormat = is24HourFormatOverride ?? contextIs24HourFormat
   const [value, setValue] = useControlledState({
     value: controlledValue,
     onValueChange: onValueChange,
@@ -149,7 +151,7 @@ export const TimePicker = ({
             <Button
               size="sm"
               color={isSelected ? 'primary' : 'neutral'}
-              key={minute + minuteIncrement} // minute increment so that scroll works
+              key={minute + minuteIncrement}
               ref={isSelected ? minuteRef : undefined}
               onClick={() => onChangeWrapper(newDate => newDate.setMinutes(minute))}
               className="min-w-16"
@@ -167,7 +169,7 @@ export const TimePicker = ({
               <Button
                 size="sm"
                 color={isSelected ? 'primary' : 'neutral'}
-                key={second + secondIncrement} // second increment so that scroll works
+                key={second + secondIncrement}
                 ref={isSelected ? minuteRef : undefined}
                 onClick={() => onChangeWrapper(newDate => newDate.setSeconds(second))}
                 className="min-w-16"
@@ -186,7 +188,7 @@ export const TimePicker = ({
               <Button
                 size="sm"
                 color={isSelected ? 'primary' : 'neutral'}
-                key={millisecond + millisecondIncrement} // millisecond increment so that scroll works
+                key={millisecond + millisecondIncrement}
                 ref={isSelected ? minuteRef : undefined}
                 onClick={() => onChangeWrapper(newDate => newDate.setMilliseconds(millisecond))}
                 className="min-w-16"

--- a/src/components/user-interaction/input/DateTimeField.tsx
+++ b/src/components/user-interaction/input/DateTimeField.tsx
@@ -54,7 +54,7 @@ export const DateTimeField = forwardRef<HTMLDivElement, DateTimeFieldProps>(func
   ...props
 }, forwardedRef) {
   const translation = useHightideTranslation()
-  const { locale: contextLocale } = useLocale()
+  const { locale: contextLocale, is24HourFormat: contextIs24HourFormat } = useLocale()
   const locale = localeOverride ?? contextLocale
 
   const [value, setValue] = useControlledState<Date | null>({
@@ -63,12 +63,7 @@ export const DateTimeField = forwardRef<HTMLDivElement, DateTimeFieldProps>(func
     defaultValue: initialValue,
   })
 
-  const is24Hour = useMemo(() => {
-    if (is24HourFormat !== undefined) {
-      return is24HourFormat
-    }
-    return !new Intl.DateTimeFormat(locale, { hour: 'numeric' }).resolvedOptions().hour12
-  }, [is24HourFormat, locale])
+  const is24Hour = is24HourFormat ?? contextIs24HourFormat ?? true
 
   const layout = useMemo(
     () => buildSegmentLayout({ locale, mode, precision, is24HourFormat: is24Hour }),

--- a/src/components/user-interaction/input/DateTimeField.tsx
+++ b/src/components/user-interaction/input/DateTimeField.tsx
@@ -110,6 +110,11 @@ export const DateTimeField = forwardRef<HTMLDivElement, DateTimeFieldProps>(func
   }
 
   useEffect(() => {
+    // Never overwrite a segment that is mid-entry: while a buffer is held the displayed digits
+    // are ahead of the committed value on purpose, and echoing the value back would clobber them.
+    if (editStateRef.current.buffer) {
+      return
+    }
     const shown = composeDate(editStateRef.current.values, layout, mode, is24Hour, value ?? undefined)
     if ((shown?.getTime() ?? null) === (value?.getTime() ?? null)) {
       return
@@ -122,6 +127,14 @@ export const DateTimeField = forwardRef<HTMLDivElement, DateTimeFieldProps>(func
 
   const apply = (next: SegmentEditState) => {
     setEditState(next)
+    // Hold off on committing a half-typed year. A one to three digit year is a valid number but
+    // almost never what the user means, and committing it would emit (and round-trip) a stray date
+    // such as 0002/1902 on the way to "2004". The year is committed once it is fully typed (the
+    // buffer clears on auto-advance) or when focus leaves the field, where a shorthand year is
+    // expanded the same way arrow stepping already does.
+    if (next.buffer?.type === 'year') {
+      return
+    }
     const composed = composeDate(next.values, layout, mode, is24Hour, value ?? undefined)
     if (composed) {
       setValue(composed)
@@ -233,6 +246,10 @@ export const DateTimeField = forwardRef<HTMLDivElement, DateTimeFieldProps>(func
       const composed = composeDate(editStateRef.current.values, layout, mode, is24Hour, value ?? undefined)
       if (composed) {
         setEditState({ values: decomposeDate(composed, layout, is24Hour), buffer: null })
+        // A deferred or shorthand year is only committed here, once the user has left the field.
+        if (composed.getTime() !== (value?.getTime() ?? null)) {
+          setValue(composed)
+        }
         onEditComplete?.(composed)
       } else {
         onEditComplete?.(value ?? null)

--- a/src/components/user-interaction/input/DateTimeField.tsx
+++ b/src/components/user-interaction/input/DateTimeField.tsx
@@ -37,12 +37,6 @@ export interface DateTimeFieldProps extends
   locale?: string,
 }
 
-/**
- * A segmented date and time editor where each part is an individually focusable spin button.
- *
- * The displayed segments always reflect the underlying value: any complete and valid edit is
- * committed immediately, so the value passed to the parent never drifts from what is shown.
- */
 export const DateTimeField = forwardRef<HTMLDivElement, DateTimeFieldProps>(function DateTimeField({
   value: controlledValue,
   initialValue = null,
@@ -110,8 +104,6 @@ export const DateTimeField = forwardRef<HTMLDivElement, DateTimeFieldProps>(func
   }
 
   useEffect(() => {
-    // Never overwrite a segment that is mid-entry: while a buffer is held the displayed digits
-    // are ahead of the committed value on purpose, and echoing the value back would clobber them.
     if (editStateRef.current.buffer) {
       return
     }
@@ -127,11 +119,6 @@ export const DateTimeField = forwardRef<HTMLDivElement, DateTimeFieldProps>(func
 
   const apply = (next: SegmentEditState) => {
     setEditState(next)
-    // Hold off on committing a half-typed year. A one to three digit year is a valid number but
-    // almost never what the user means, and committing it would emit (and round-trip) a stray date
-    // such as 0002/1902 on the way to "2004". The year is committed once it is fully typed (the
-    // buffer clears on auto-advance) or when focus leaves the field, where a shorthand year is
-    // expanded the same way arrow stepping already does.
     if (next.buffer?.type === 'year') {
       return
     }
@@ -238,9 +225,6 @@ export const DateTimeField = forwardRef<HTMLDivElement, DateTimeFieldProps>(func
   const onFieldBlur = (event: FocusEvent<HTMLDivElement>) => {
     props.onBlur?.(event)
     const field = event.currentTarget
-    // Moving focus to another segment of the same field (auto-advance, tab, arrow keys) is not the
-    // end of editing. relatedTarget tells us where focus is heading, so we can ignore those moves
-    // synchronously instead of mistaking the brief focus gap for the user leaving the field.
     const nextFocus = event.relatedTarget
     if (nextFocus instanceof Node && field.contains(nextFocus)) {
       return
@@ -253,7 +237,6 @@ export const DateTimeField = forwardRef<HTMLDivElement, DateTimeFieldProps>(func
       const composed = composeDate(editStateRef.current.values, layout, mode, is24Hour, value ?? undefined)
       if (composed) {
         setEditState({ values: decomposeDate(composed, layout, is24Hour), buffer: null })
-        // A deferred or shorthand year is only committed here, once the user has left the field.
         if (composed.getTime() !== (value?.getTime() ?? null)) {
           setValue(composed)
         }

--- a/src/components/user-interaction/input/DateTimeField.tsx
+++ b/src/components/user-interaction/input/DateTimeField.tsx
@@ -238,6 +238,13 @@ export const DateTimeField = forwardRef<HTMLDivElement, DateTimeFieldProps>(func
   const onFieldBlur = (event: FocusEvent<HTMLDivElement>) => {
     props.onBlur?.(event)
     const field = event.currentTarget
+    // Moving focus to another segment of the same field (auto-advance, tab, arrow keys) is not the
+    // end of editing. relatedTarget tells us where focus is heading, so we can ignore those moves
+    // synchronously instead of mistaking the brief focus gap for the user leaving the field.
+    const nextFocus = event.relatedTarget
+    if (nextFocus instanceof Node && field.contains(nextFocus)) {
+      return
+    }
     requestAnimationFrame(() => {
       if (field.contains(document.activeElement)) {
         return

--- a/src/components/user-interaction/input/DateTimeInput.tsx
+++ b/src/components/user-interaction/input/DateTimeInput.tsx
@@ -12,7 +12,7 @@ import { PropsUtil } from '@/src/utils/propsUtil'
 import type { FormFieldInteractionStates } from '@/src/components/form/FieldLayout'
 import { PopUp } from '../../layout/popup/PopUp'
 import { IconButton } from '../IconButton'
-import type { DateTimeFormat } from '@/src/utils/date'
+import { DateUtils, type DateTimeFormat } from '@/src/utils/date'
 import { DateTimeField } from './DateTimeField'
 
 export interface DateTimeInputProps extends
@@ -26,6 +26,13 @@ export interface DateTimeInputProps extends
   /** Shows a clear button on optional fields with a value. Has no effect when required. Defaults to true */
   allowClear?: boolean,
   mode?: DateTimeFormat,
+  /**
+   * Display and edit the value as the wall clock of this IANA time zone (e.g. `'Europe/Berlin'`,
+   * `'UTC'`) instead of the viewer's local zone. The value contract is unchanged: `value`,
+   * `onValueChange` and `onEditComplete` keep using absolute `Date` instants — only the segments
+   * the user sees and types are interpreted in this zone. Leave undefined to use the local zone.
+   */
+  timeZone?: string,
   containerProps?: HTMLAttributes<HTMLDivElement>,
   pickerProps?: Omit<DateTimePickerProps, keyof FormFieldDataHandling<Date> | 'mode' | 'initialValue' | 'start' | 'end' | 'weekStart' | 'markToday' | 'is24HourFormat' | 'minuteIncrement' | 'secondIncrement' | 'millisecondIncrement' | 'precision'>,
   outsideClickCloses?: boolean,
@@ -50,6 +57,7 @@ export const DateTimeInput = forwardRef<HTMLDivElement, DateTimeInputProps>(func
   allowClear = true,
   containerProps,
   mode = 'date',
+  timeZone,
   precision = 'minute',
   pickerProps,
   outsideClickCloses = true,
@@ -82,6 +90,12 @@ export const DateTimeInput = forwardRef<HTMLDivElement, DateTimeInputProps>(func
     onDialogOpeningChange?.(isOpen)
     setIsOpen(isOpen)
   }, [onDialogOpeningChange])
+
+  // The field and calendar always work in the local wall clock. When a time zone is given we hand
+  // them a value shifted to that zone's wall clock and convert every edit back to an absolute
+  // instant on the way out, so the public value contract stays time-zone agnostic.
+  const toZoned = useCallback((date: Date | null) => DateUtils.toZonedDate(date, timeZone), [timeZone])
+  const fromZoned = useCallback((date: Date | null) => DateUtils.fromZonedDate(date, timeZone), [timeZone])
 
   const generatedId = useId()
   const ids = useMemo(() => ({
@@ -134,7 +148,7 @@ export const DateTimeInput = forwardRef<HTMLDivElement, DateTimeInputProps>(func
       >
         <DateTimeField
           ref={fieldRef}
-          value={state}
+          value={toZoned(state)}
           mode={mode}
           precision={precision}
           is24HourFormat={is24HourFormat}
@@ -142,8 +156,8 @@ export const DateTimeInput = forwardRef<HTMLDivElement, DateTimeInputProps>(func
           readOnly={readOnly}
           invalid={invalid}
           required={required}
-          onValueChange={setState}
-          onEditComplete={onEditComplete}
+          onValueChange={(next) => setState(fromZoned(next))}
+          onEditComplete={(next) => onEditComplete?.(fromZoned(next))}
           aria-labelledby={props['aria-labelledby']}
           aria-describedby={props['aria-describedby']}
           className="grow"
@@ -201,18 +215,19 @@ export const DateTimeInput = forwardRef<HTMLDivElement, DateTimeInputProps>(func
         className="flex-col-2 p-2"
       >
         <DateTimePickerDialog
-          value={dialogValue}
+          value={toZoned(dialogValue)}
           allowRemove={allowRemove}
-          onValueChange={setDialogValue}
+          onValueChange={(value) => setDialogValue(fromZoned(value))}
           onEditComplete={(value) => {
-            setState(value)
-            onEditComplete?.(value)
+            const absolute = fromZoned(value)
+            setState(absolute)
+            onEditComplete?.(absolute)
             changeOpenWrapper(false)
           }}
           pickerProps={pickerProps}
           mode={mode}
-          start={start}
-          end={end}
+          start={toZoned(start ?? null) ?? undefined}
+          end={toZoned(end ?? null) ?? undefined}
           weekStart={weekStart}
           markToday={markToday}
           is24HourFormat={is24HourFormat}

--- a/src/components/user-interaction/input/DateTimeInput.tsx
+++ b/src/components/user-interaction/input/DateTimeInput.tsx
@@ -4,6 +4,7 @@ import { CalendarIcon, X } from 'lucide-react'
 import clsx from 'clsx'
 import type { DateTimePickerProps } from '@/src/components/user-interaction/date/DateTimePicker'
 import { useHightideTranslation } from '@/src/i18n/useHightideTranslation'
+import { useLocale } from '@/src/global-contexts/LocaleContext'
 import { Visibility } from '@/src/components/layout/Visibility'
 import type { FormFieldDataHandling } from '../../form/FormField'
 import { DateTimePickerDialog } from '../date/DateTimePickerDialog'
@@ -23,15 +24,8 @@ export interface DateTimeInputProps extends
 {
   initialValue?: Date | null,
   allowRemove?: boolean,
-  /** Shows a clear button on optional fields with a value. Has no effect when required. Defaults to true */
   allowClear?: boolean,
   mode?: DateTimeFormat,
-  /**
-   * Display and edit the value as the wall clock of this IANA time zone (e.g. `'Europe/Berlin'`,
-   * `'UTC'`) instead of the viewer's local zone. The value contract is unchanged: `value`,
-   * `onValueChange` and `onEditComplete` keep using absolute `Date` instants — only the segments
-   * the user sees and types are interpreted in this zone. Leave undefined to use the local zone.
-   */
   timeZone?: string,
   containerProps?: HTMLAttributes<HTMLDivElement>,
   pickerProps?: Omit<DateTimePickerProps, keyof FormFieldDataHandling<Date> | 'mode' | 'initialValue' | 'start' | 'end' | 'weekStart' | 'markToday' | 'is24HourFormat' | 'minuteIncrement' | 'secondIncrement' | 'millisecondIncrement' | 'precision'>,
@@ -40,13 +34,6 @@ export interface DateTimeInputProps extends
   actions?: ReactNode[],
 }
 
-/**
- * An input for picking a date, a time or both.
- *
- * The value can be typed segment by segment with the keyboard or selected from the calendar
- * dialog. Both paths write to the same value, so the displayed input and the stored value
- * always stay in sync.
- */
 export const DateTimeInput = forwardRef<HTMLDivElement, DateTimeInputProps>(function DateTimeInput({
   id: inputId,
   value,
@@ -57,7 +44,7 @@ export const DateTimeInput = forwardRef<HTMLDivElement, DateTimeInputProps>(func
   allowClear = true,
   containerProps,
   mode = 'date',
-  timeZone,
+  timeZone: timeZoneOverride,
   precision = 'minute',
   pickerProps,
   outsideClickCloses = true,
@@ -78,6 +65,8 @@ export const DateTimeInput = forwardRef<HTMLDivElement, DateTimeInputProps>(func
   ...props
 }, forwardedRef) {
   const translation = useHightideTranslation()
+  const { timeZone: contextTimeZone } = useLocale()
+  const timeZone = timeZoneOverride ?? contextTimeZone
   const [isOpen, setIsOpen] = useState(false)
   const [state, setState] = useControlledState<Date | null>({
     value,
@@ -91,9 +80,6 @@ export const DateTimeInput = forwardRef<HTMLDivElement, DateTimeInputProps>(func
     setIsOpen(isOpen)
   }, [onDialogOpeningChange])
 
-  // The field and calendar always work in the local wall clock. When a time zone is given we hand
-  // them a value shifted to that zone's wall clock and convert every edit back to an absolute
-  // instant on the way out, so the public value contract stays time-zone agnostic.
   const toZoned = useCallback((date: Date | null) => DateUtils.toZonedDate(date, timeZone), [timeZone])
   const fromZoned = useCallback((date: Date | null) => DateUtils.fromZonedDate(date, timeZone), [timeZone])
 

--- a/src/components/user-interaction/input/FlexibleDateTimeInput.tsx
+++ b/src/components/user-interaction/input/FlexibleDateTimeInput.tsx
@@ -5,30 +5,26 @@ import { DateTimeInput, type DateTimeInputProps } from './DateTimeInput'
 import { useControlledState } from '@/src/hooks/useControlledState'
 import { IconButton } from '../IconButton'
 import { useHightideTranslation } from '@/src/i18n/useHightideTranslation'
+import { useLocale } from '@/src/global-contexts/LocaleContext'
 
 export interface FlexibleDateTimeInputProps extends Omit<DateTimeInputProps, 'mode'> {
   defaultMode: Exclude<DateTimeFormat, 'time'>,
-  /** The time of day used while no explicit time is set. Defaults to 23:59:59.999 */
   fixedTime?: Date | null,
 }
 
-/**
- * A date input that can optionally be extended with a time.
- *
- * While only a date is shown the value is anchored to a fixed time of day (end of day by
- * default). Adding a time switches to a full date and time editor seeded with the current time.
- */
 export const FlexibleDateTimeInput = forwardRef<HTMLDivElement, FlexibleDateTimeInputProps>(function FlexibleDateTimeInput({
   defaultMode = 'date',
   value: controlledValue,
   initialValue,
   onValueChange,
   fixedTime: fixedTimeOverride,
-  timeZone,
+  timeZone: timeZoneOverride,
   actions = [],
   ...props
 }, forwardedRef) {
   const translation = useHightideTranslation()
+  const { timeZone: contextTimeZone } = useLocale()
+  const timeZone = timeZoneOverride ?? contextTimeZone
   const fixedTime = fixedTimeOverride ?? new Date(1970, 0, 1, 23, 59, 59, 999)
   const [value, setValue] = useControlledState<Date | null>({
     value: controlledValue,
@@ -36,9 +32,6 @@ export const FlexibleDateTimeInput = forwardRef<HTMLDivElement, FlexibleDateTime
     defaultValue: initialValue,
   })
 
-  // The "fixed time" anchor is a wall clock concept, so the comparisons and rewrites below happen
-  // in the display zone. Values stay absolute instants on the wire; only this internal time math
-  // is shifted into the chosen zone.
   const zoned = (date: Date) => DateUtils.toZonedDate(date, timeZone)
   const unzoned = (date: Date) => DateUtils.fromZonedDate(date, timeZone)
   const hasFixedTime = (date: Date) => DateUtils.sameTime(zoned(date), fixedTime, true, true)

--- a/src/components/user-interaction/input/FlexibleDateTimeInput.tsx
+++ b/src/components/user-interaction/input/FlexibleDateTimeInput.tsx
@@ -24,6 +24,7 @@ export const FlexibleDateTimeInput = forwardRef<HTMLDivElement, FlexibleDateTime
   initialValue,
   onValueChange,
   fixedTime: fixedTimeOverride,
+  timeZone,
   actions = [],
   ...props
 }, forwardedRef) {
@@ -34,20 +35,29 @@ export const FlexibleDateTimeInput = forwardRef<HTMLDivElement, FlexibleDateTime
     onValueChange,
     defaultValue: initialValue,
   })
+
+  // The "fixed time" anchor is a wall clock concept, so the comparisons and rewrites below happen
+  // in the display zone. Values stay absolute instants on the wire; only this internal time math
+  // is shifted into the chosen zone.
+  const zoned = (date: Date) => DateUtils.toZonedDate(date, timeZone)
+  const unzoned = (date: Date) => DateUtils.fromZonedDate(date, timeZone)
+  const hasFixedTime = (date: Date) => DateUtils.sameTime(zoned(date), fixedTime, true, true)
+
   const [mode, setMode] = useState<Exclude<DateTimeFormat, 'time'>>(() => {
-    if (value && !DateUtils.sameTime(value, fixedTime, true, true)) {
+    if (value && !hasFixedTime(value)) {
       return 'dateTime'
     }
     return defaultMode
   })
 
-  const toDate = (date: Date) => DateUtils.withTime(date, fixedTime)
-  const toDateTime = (date: Date) => DateUtils.sameTime(date, fixedTime, true, true) ? DateUtils.withTime(date, new Date()) : date
+  const toDate = (date: Date) => unzoned(DateUtils.withTime(zoned(date), fixedTime))
+  const toDateTime = (date: Date) => hasFixedTime(date) ? unzoned(DateUtils.withTime(zoned(date), zoned(new Date()))) : date
 
   return (
     <DateTimeInput
       {...props}
       ref={forwardedRef}
+      timeZone={timeZone}
       mode={mode}
       value={value}
       onValueChange={(next) => {

--- a/src/components/user-interaction/properties/DateProperty.tsx
+++ b/src/components/user-interaction/properties/DateProperty.tsx
@@ -1,37 +1,57 @@
 import { CalendarDays } from 'lucide-react'
 import { PropertyBase, type PropertyField } from './PropertyBase'
-import { DateTimeInput } from '../input/DateTimeInput'
+import { DateTimeInput, type DateTimeInputProps } from '../input/DateTimeInput'
 import { PropsUtil } from '@/src/utils/propsUtil'
 
-export type DatePropertyProps = PropertyField<Date>
-& {
-  type?: 'dateTime' | 'date',
-}
+export type DatePropertyProps =
+  Pick<PropertyField<Date | null>, 'name' | 'onRemove' | 'onValueClear'>
+  & Omit<DateTimeInputProps, 'mode' | 'allowRemove'>
+  & {
+    type?: 'dateTime' | 'date',
+    allowRemove?: boolean,
+  }
 
-/**
- * An Input for date properties
- */
 export const DateProperty = ({
+  name,
   value,
   onValueChange,
   onEditComplete,
+  onRemove,
+  onValueClear,
+  required,
   readOnly,
+  allowClear = true,
+  allowRemove = true,
   type = 'dateTime',
-  ...baseProps
+  className,
+  ...inputProps
 }: DatePropertyProps) => {
   const hasValue = !!value
 
   return (
     <PropertyBase
-      {...baseProps}
+      name={name}
+      required={required}
+      readOnly={readOnly}
+      allowClear={allowClear}
+      allowRemove={allowRemove}
+      onRemove={onRemove}
+      onValueClear={onValueClear ?? (() => {
+        onValueChange?.(null)
+        onEditComplete?.(null)
+      })}
       hasValue={hasValue}
       icon={<CalendarDays size={24}/>}
+      className={className}
     >
       {({ invalid }) => (
         <DateTimeInput
+          {...inputProps}
           value={value}
           mode={type}
+          required={required}
           readOnly={readOnly}
+          allowClear={false}
           onValueChange={onValueChange}
           onEditComplete={onEditComplete}
           data-name="property-input"

--- a/src/global-contexts/HightideConfigContext.tsx
+++ b/src/global-contexts/HightideConfigContext.tsx
@@ -4,29 +4,17 @@ import type { HightideTranslationLocales } from '@/src/i18n/translations'
 import type { DeepPartial } from '@/src/utils/typing'
 
 export type TooltipConfig = {
-  /**
-   * Number of milliseconds until the tooltip appears
-   */
   appearDelay: number,
   isAnimated: boolean,
 }
 
 export type ThemeConfig = {
-  /**
-   * The initial theme to show when:
-   * 1. The system preference is not or cannot be loaded
-   * 2. The user has not set an app preference
-   */
   initialTheme: ResolvedTheme,
 }
 
 export type LocalizationConfig = {
-  /**
-   * The initial locale to use when:
-   * 1. The system preference is not or cannot be loaded
-   * 2. The user has not set an app preference
-   */
   defaultLocale: HightideTranslationLocales,
+  defaultTimeZone?: string,
 }
 
 export type HightideConfig = {

--- a/src/global-contexts/HightideConfigContext.tsx
+++ b/src/global-contexts/HightideConfigContext.tsx
@@ -15,6 +15,7 @@ export type ThemeConfig = {
 export type LocalizationConfig = {
   defaultLocale: HightideTranslationLocales,
   defaultTimeZone?: string,
+  defaultIs24HourFormat?: boolean,
 }
 
 export type HightideConfig = {

--- a/src/global-contexts/LocaleContext.tsx
+++ b/src/global-contexts/LocaleContext.tsx
@@ -12,6 +12,8 @@ export type LocaleContextValue = {
   setLocale: Dispatch<SetStateAction<HightideTranslationLocales>>,
   timeZone?: string,
   setTimeZone?: (timeZone: string | undefined) => void,
+  is24HourFormat?: boolean,
+  setIs24HourFormat?: (is24HourFormat: boolean | undefined) => void,
 }
 
 export const LocaleContext = createContext<LocaleContextValue | null>(null)
@@ -23,6 +25,8 @@ export type LocaleProviderProps = PropsWithChildren & Partial<LocalizationConfig
   onChangedLocale?: (locale: HightideTranslationLocales) => void,
   timeZone?: string,
   onChangedTimeZone?: (timeZone: string | undefined) => void,
+  is24HourFormat?: boolean,
+  onChangedIs24HourFormat?: (is24HourFormat: boolean) => void,
 }
 
 export const LocaleProvider = ({
@@ -30,9 +34,12 @@ export const LocaleProvider = ({
   locale,
   defaultLocale,
   defaultTimeZone,
+  defaultIs24HourFormat,
   timeZone,
+  is24HourFormat,
   onChangedLocale,
   onChangedTimeZone,
+  onChangedIs24HourFormat,
 }: LocaleProviderProps) => {
   const {
     value: storedLocale,
@@ -44,6 +51,11 @@ export const LocaleProvider = ({
     setValue: setStoredTimeZone,
     deleteValue: deleteStoredTimeZone,
   } = useStorage<string | undefined>({ key: 'timeZone', defaultValue: undefined })
+  const {
+    value: storedIs24HourFormat,
+    setValue: setStoredIs24HourFormat,
+    deleteValue: deleteStoredIs24HourFormat,
+  } = useStorage<boolean | undefined>({ key: 'is24HourFormat', defaultValue: undefined })
   const { config } = useHightideConfig()
   const [localePreference, setLocalePreference] = useState<LocaleWithSystem>('system')
 
@@ -78,6 +90,15 @@ export const LocaleProvider = ({
     setStoredTimeZone(timeZone)
   }, [timeZone, setStoredTimeZone])
 
+  const resolvedIs24HourFormat = useMemo(() => {
+    return is24HourFormat ?? storedIs24HourFormat ?? config.locale.defaultIs24HourFormat ?? defaultIs24HourFormat ?? true
+  }, [is24HourFormat, storedIs24HourFormat, config.locale.defaultIs24HourFormat, defaultIs24HourFormat])
+
+  useEffect(() => {
+    if (is24HourFormat === undefined) return
+    setStoredIs24HourFormat(is24HourFormat)
+  }, [is24HourFormat, setStoredIs24HourFormat])
+
   const onChangeRef = useEventCallbackStabilizer(onChangedLocale)
 
   useEffect(() => {
@@ -89,6 +110,12 @@ export const LocaleProvider = ({
   useEffect(() => {
     onChangeTimeZoneRef?.(resolvedTimeZone)
   }, [resolvedTimeZone, onChangeTimeZoneRef])
+
+  const onChangeIs24HourFormatRef = useEventCallbackStabilizer(onChangedIs24HourFormat)
+
+  useEffect(() => {
+    onChangeIs24HourFormatRef?.(resolvedIs24HourFormat)
+  }, [resolvedIs24HourFormat, onChangeIs24HourFormatRef])
 
   useEffect(() => {
     const localesToTestAgainst = Object.values(LocalizationUtil.locals)
@@ -139,6 +166,20 @@ export const LocaleProvider = ({
           setStoredTimeZone(newTimeZone)
         }
       },
+      is24HourFormat: resolvedIs24HourFormat,
+      setIs24HourFormat: (newIs24HourFormat) => {
+        if (is24HourFormat !== undefined) {
+          console.warn('LocaleProvider: Attempting to change the ' +
+            "hour format while setting a fixed hour format won't have any effect. " +
+            'Change the is24HourFormat provided to the LocaleProvider instead.')
+          return
+        }
+        if (newIs24HourFormat === undefined) {
+          deleteStoredIs24HourFormat()
+        } else {
+          setStoredIs24HourFormat(newIs24HourFormat)
+        }
+      },
     }}>
       {children}
     </LocaleContext.Provider>
@@ -159,6 +200,14 @@ export const useTimeZone = () => {
     throw new Error('useTimeZone must be used within LocaleContext. Try adding a LocaleProvider around your app.')
   }
   return { timeZone: context.timeZone, setTimeZone: context.setTimeZone }
+}
+
+export const useDateTimeFormat = () => {
+  const context = useContext(LocaleContext)
+  return {
+    is24HourFormat: context?.is24HourFormat ?? true,
+    timeZone: context?.timeZone,
+  }
 }
 
 export const useLanguage = () => {

--- a/src/global-contexts/LocaleContext.tsx
+++ b/src/global-contexts/LocaleContext.tsx
@@ -10,6 +10,8 @@ import { useEventCallbackStabilizer } from '../hooks/useEventCallbackStabelizer'
 export type LocaleContextValue = {
   locale: HightideTranslationLocales,
   setLocale: Dispatch<SetStateAction<HightideTranslationLocales>>,
+  timeZone?: string,
+  setTimeZone?: (timeZone: string | undefined) => void,
 }
 
 export const LocaleContext = createContext<LocaleContextValue | null>(null)
@@ -19,19 +21,29 @@ type LocaleWithSystem = HightideTranslationLocales | 'system'
 export type LocaleProviderProps = PropsWithChildren & Partial<LocalizationConfig> & {
   locale?: LocaleWithSystem,
   onChangedLocale?: (locale: HightideTranslationLocales) => void,
+  timeZone?: string,
+  onChangedTimeZone?: (timeZone: string | undefined) => void,
 }
 
 export const LocaleProvider = ({
   children,
   locale,
   defaultLocale,
-  onChangedLocale
+  defaultTimeZone,
+  timeZone,
+  onChangedLocale,
+  onChangedTimeZone,
 }: LocaleProviderProps) => {
   const {
     value: storedLocale,
     setValue: setStoredLocale,
     deleteValue: deleteStoredLocale,
   } = useStorage<LocaleWithSystem>({ key: 'locale', defaultValue: 'system' })
+  const {
+    value: storedTimeZone,
+    setValue: setStoredTimeZone,
+    deleteValue: deleteStoredTimeZone,
+  } = useStorage<string | undefined>({ key: 'timeZone', defaultValue: undefined })
   const { config } = useHightideConfig()
   const [localePreference, setLocalePreference] = useState<LocaleWithSystem>('system')
 
@@ -57,11 +69,26 @@ export const LocaleProvider = ({
     }
   }, [locale, deleteStoredLocale, setStoredLocale])
 
+  const resolvedTimeZone = useMemo(() => {
+    return timeZone ?? storedTimeZone ?? config.locale.defaultTimeZone ?? defaultTimeZone
+  }, [timeZone, storedTimeZone, config.locale.defaultTimeZone, defaultTimeZone])
+
+  useEffect(() => {
+    if (timeZone === undefined) return
+    setStoredTimeZone(timeZone)
+  }, [timeZone, setStoredTimeZone])
+
   const onChangeRef = useEventCallbackStabilizer(onChangedLocale)
 
   useEffect(() => {
     onChangeRef?.(resolvedLocale)
   }, [resolvedLocale, onChangeRef])
+
+  const onChangeTimeZoneRef = useEventCallbackStabilizer(onChangedTimeZone)
+
+  useEffect(() => {
+    onChangeTimeZoneRef?.(resolvedTimeZone)
+  }, [resolvedTimeZone, onChangeTimeZoneRef])
 
   useEffect(() => {
     const localesToTestAgainst = Object.values(LocalizationUtil.locals)
@@ -97,7 +124,21 @@ export const LocaleProvider = ({
             'Change the locale provided to the LocaleProvider instead.')
         }
         setStoredLocale(newLocale)
-      }
+      },
+      timeZone: resolvedTimeZone,
+      setTimeZone: (newTimeZone) => {
+        if (timeZone !== undefined) {
+          console.warn('LocaleProvider: Attempting to change the ' +
+            "time zone while setting a fixed time zone won't have any effect. " +
+            'Change the timeZone provided to the LocaleProvider instead.')
+          return
+        }
+        if (newTimeZone === undefined) {
+          deleteStoredTimeZone()
+        } else {
+          setStoredTimeZone(newTimeZone)
+        }
+      },
     }}>
       {children}
     </LocaleContext.Provider>
@@ -110,6 +151,14 @@ export const useLocale = () => {
     throw new Error('useLocale must be used within LocaleContext. Try adding a LocaleProvider around your app.')
   }
   return context
+}
+
+export const useTimeZone = () => {
+  const context = useContext(LocaleContext)
+  if (!context) {
+    throw new Error('useTimeZone must be used within LocaleContext. Try adding a LocaleProvider around your app.')
+  }
+  return { timeZone: context.timeZone, setTimeZone: context.setTimeZone }
 }
 
 export const useLanguage = () => {

--- a/src/hooks/useUpdatingDateString.ts
+++ b/src/hooks/useUpdatingDateString.ts
@@ -7,6 +7,8 @@ export interface UseUpdatingDateStringProps {
   date: Date,
   absoluteFormat?: DateTimeFormat,
   localeOverride?: HightideTranslationLocales,
+  is24HourFormat?: boolean,
+  timeZone?: string,
 }
 
 type DateAndTimeStrings = {
@@ -15,23 +17,24 @@ type DateAndTimeStrings = {
   relative: string,
 }
 
-export const useUpdatingDateString = ({ absoluteFormat = 'dateTime', localeOverride, date }: UseUpdatingDateStringProps) => {
-  // TODO add a parameter to the hightide cofig
-  const { locale: contextLocale } = useLocale()
+export const useUpdatingDateString = ({ absoluteFormat = 'dateTime', localeOverride, is24HourFormat: is24HourFormatOverride, timeZone: timeZoneOverride, date }: UseUpdatingDateStringProps) => {
+  const { locale: contextLocale, is24HourFormat: contextIs24HourFormat, timeZone: contextTimeZone } = useLocale()
   const locale = localeOverride ?? contextLocale
+  const is24HourFormat = is24HourFormatOverride ?? contextIs24HourFormat ?? true
+  const timeZone = timeZoneOverride ?? contextTimeZone
   const [dateAndTimeStrings, setDateAndTimeStrings] = useState<DateAndTimeStrings>({
     compareDate: date,
-    absolute: DateUtils.formatAbsolute(date, locale, absoluteFormat),
+    absolute: DateUtils.formatAbsolute(date, locale, absoluteFormat, { is24HourFormat, timeZone }),
     relative: DateUtils.formatRelative(date, locale),
   })
 
   useEffect(() => {
     setDateAndTimeStrings({
       compareDate: date,
-      absolute: DateUtils.formatAbsolute(date, locale, absoluteFormat),
+      absolute: DateUtils.formatAbsolute(date, locale, absoluteFormat, { is24HourFormat, timeZone }),
       relative: DateUtils.formatRelative(date, locale),
     })
-  }, [date, absoluteFormat, locale])
+  }, [date, absoluteFormat, locale, is24HourFormat, timeZone])
 
   useEffect(() => {
     let timeoutId: NodeJS.Timeout
@@ -53,17 +56,16 @@ export const useUpdatingDateString = ({ absoluteFormat = 'dateTime', localeOverr
       timeoutId = setInterval(() => {
         setDateAndTimeStrings({
           compareDate: date,
-          absolute: DateUtils.formatAbsolute(date, locale, absoluteFormat),
+          absolute: DateUtils.formatAbsolute(date, locale, absoluteFormat, { is24HourFormat, timeZone }),
           relative: DateUtils.formatRelative(date, locale),
         })
-        // We divide by 2 to have cleaner updates
       }, delayInSeconds * 1000 / 2)
     }
 
     startTimer()
 
     return () => clearInterval(timeoutId)
-  }, [absoluteFormat, date, locale])
+  }, [absoluteFormat, date, locale, is24HourFormat, timeZone])
 
   return {
     absolute: dateAndTimeStrings.absolute,

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -251,8 +251,19 @@ const weeksForCalenderMonth = (date: Date, weekStart: WeekDay, weeks: number = 6
   return equalSizeGroups(dayList, 7)
 }
 
-const formatAbsolute = (date: Date, locale: string, format: DateTimeFormat) => {
+type FormatAbsoluteOptions = {
+  timeZone?: string,
+  is24HourFormat?: boolean,
+}
+
+const formatAbsolute = (date: Date, locale: string, format: DateTimeFormat, { timeZone, is24HourFormat = true }: FormatAbsoluteOptions = {}) => {
   let options: Intl.DateTimeFormatOptions
+
+  const timeOptions: Intl.DateTimeFormatOptions = {
+    hour: '2-digit',
+    minute: '2-digit',
+    hourCycle: is24HourFormat ? 'h23' : 'h12',
+  }
 
   switch (format) {
   case 'date':
@@ -264,8 +275,7 @@ const formatAbsolute = (date: Date, locale: string, format: DateTimeFormat) => {
     break
   case 'time':
     options = {
-      hour: '2-digit',
-      minute: '2-digit',
+      ...timeOptions,
     }
     break
   case 'dateTime':
@@ -273,13 +283,12 @@ const formatAbsolute = (date: Date, locale: string, format: DateTimeFormat) => {
       year: 'numeric',
       month: '2-digit',
       day: '2-digit',
-      hour: '2-digit',
-      minute: '2-digit',
+      ...timeOptions,
     }
     break
   }
 
-  return new Intl.DateTimeFormat(locale, options).format(date)
+  return new Intl.DateTimeFormat(locale, { ...options, timeZone }).format(date)
 }
 
 const formatRelative = (date: Date, locale: string) => {

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -152,6 +152,107 @@ const withTime = (datePart: Date, timePart: Date): Date => {
   return out
 }
 
+type ZonedParts = {
+  year: number,
+  /** 1-based month, matching the human reading of a clock rather than Date#getMonth. */
+  month: number,
+  day: number,
+  hour: number,
+  minute: number,
+  second: number,
+  millisecond: number,
+}
+
+const zonedPartsFormatterCache = new Map<string, Intl.DateTimeFormat>()
+
+const zonedPartsFormatter = (timeZone: string): Intl.DateTimeFormat => {
+  let formatter = zonedPartsFormatterCache.get(timeZone)
+  if (!formatter) {
+    formatter = new Intl.DateTimeFormat('en-US', {
+      timeZone,
+      hourCycle: 'h23',
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+      hour: '2-digit',
+      minute: '2-digit',
+      second: '2-digit',
+    })
+    zonedPartsFormatterCache.set(timeZone, formatter)
+  }
+  return formatter
+}
+
+/** The wall clock fields of an instant as observed in the given IANA time zone. */
+const zonedParts = (date: Date, timeZone: string): ZonedParts => {
+  const parts: Record<string, string> = {}
+  for (const part of zonedPartsFormatter(timeZone).formatToParts(date)) {
+    if (part.type !== 'literal') {
+      parts[part.type] = part.value
+    }
+  }
+  return {
+    year: Number(parts.year),
+    month: Number(parts.month),
+    day: Number(parts.day),
+    // h23 still renders midnight as '24' in some engines, so fold it back to 0.
+    hour: Number(parts.hour) % 24,
+    minute: Number(parts.minute),
+    second: Number(parts.second),
+    // Milliseconds are identical in every time zone, so read them straight off the instant.
+    millisecond: date.getMilliseconds(),
+  }
+}
+
+const zoneOffsetMs = (date: Date, timeZone: string): number => {
+  const parts = zonedParts(date, timeZone)
+  const asUtc = Date.UTC(parts.year, parts.month - 1, parts.day, parts.hour, parts.minute, parts.second, parts.millisecond)
+  return asUtc - date.getTime()
+}
+
+/**
+ * Re-expresses an absolute instant as a "wall clock" Date in the runtime's local zone whose
+ * fields (getFullYear, getHours, …) read the same as a clock standing in `timeZone`.
+ *
+ * Passing no time zone returns the input unchanged, so an optional override can be threaded
+ * through without branching. The result is only meant for reading or editing the displayed
+ * fields; convert it back with {@link fromZonedDate} before exposing it as a real value again.
+ */
+function toZonedDate(date: Date, timeZone?: string): Date
+function toZonedDate(date: null, timeZone?: string): null
+function toZonedDate(date: Date | null, timeZone?: string): Date | null
+function toZonedDate(date: Date | null, timeZone?: string): Date | null {
+  if (!date || !timeZone) {
+    return date
+  }
+  const parts = zonedParts(date, timeZone)
+  return new Date(parts.year, parts.month - 1, parts.day, parts.hour, parts.minute, parts.second, parts.millisecond)
+}
+
+/**
+ * Inverse of {@link toZonedDate}: reads the local wall clock fields of `date` as if they were
+ * a clock reading in `timeZone` and returns the matching absolute instant.
+ */
+function fromZonedDate(date: Date, timeZone?: string): Date
+function fromZonedDate(date: null, timeZone?: string): null
+function fromZonedDate(date: Date | null, timeZone?: string): Date | null
+function fromZonedDate(date: Date | null, timeZone?: string): Date | null {
+  if (!date || !timeZone) {
+    return date
+  }
+  const asUtc = Date.UTC(
+    date.getFullYear(), date.getMonth(), date.getDate(),
+    date.getHours(), date.getMinutes(), date.getSeconds(), date.getMilliseconds()
+  )
+  // Two passes so a wall clock sitting next to a DST transition resolves to the correct offset.
+  let offset = zoneOffsetMs(new Date(asUtc), timeZone)
+  const refined = zoneOffsetMs(new Date(asUtc - offset), timeZone)
+  if (refined !== offset) {
+    offset = refined
+  }
+  return new Date(asUtc - offset)
+}
+
 const weeksForCalenderMonth = (date: Date, weekStart: WeekDay, weeks: number = 6) => {
   const month = date.getMonth()
   const year = date.getFullYear()
@@ -297,6 +398,9 @@ export const DateUtils = {
   daysInMonth,
   sameTime,
   withTime,
+  zonedParts,
+  toZonedDate,
+  fromZonedDate,
   formatAbsolute,
   formatRelative,
   addDuration,

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -12,8 +12,8 @@ const timesInSeconds = {
   hour: 3600,
   day: 86400,
   week: 604800,
-  monthImprecise: 2629800, // 30.4375 days
-  yearImprecise: 31557600, // 365.25 days
+  monthImprecise: 2629800,
+  yearImprecise: 31557600,
 } as const
 
 
@@ -34,7 +34,6 @@ const changeDuration = (date: Date, duration: Partial<DurationJSON>, isAdding?: 
     milliseconds = 0,
   } = duration
 
-  // Check ranges
   if (years < 0) {
     console.error(`Range error years must be greater than 0: received ${years}`)
     return new Date(date)
@@ -93,10 +92,6 @@ const subtractDuration = (date: Date, duration: Partial<DurationJSON>): Date => 
   return changeDuration(date, duration, false)
 }
 
-/** Checks if a given date is in the range of two dates
- *
- * An undefined value for startDate or endDate means no bound for the start or end respectively
- */
 const between = (value: Date, startDate?: Date, endDate?: Date): boolean => {
   if (startDate && endDate) {
     console.assert(startDate <= endDate)
@@ -110,7 +105,6 @@ const between = (value: Date, startDate?: Date, endDate?: Date): boolean => {
   }
 }
 
-/** Compare two dates on the year, month, day */
 const equalDate = (date1: Date, date2: Date) => {
   return date1.getFullYear() === date2.getFullYear()
     && date1.getMonth() === date2.getMonth()
@@ -122,7 +116,6 @@ const isLastMillisecondOfDay = (date: Date): boolean => {
   return !equalDate(date, next)
 }
 
-/** The number of days in the given month, where monthIndex is 0-based (0 = January) */
 const daysInMonth = (year: number, monthIndex: number): number => {
   return new Date(year, monthIndex + 1, 0).getDate()
 }
@@ -154,7 +147,6 @@ const withTime = (datePart: Date, timePart: Date): Date => {
 
 type ZonedParts = {
   year: number,
-  /** 1-based month, matching the human reading of a clock rather than Date#getMonth. */
   month: number,
   day: number,
   hour: number,
@@ -183,7 +175,6 @@ const zonedPartsFormatter = (timeZone: string): Intl.DateTimeFormat => {
   return formatter
 }
 
-/** The wall clock fields of an instant as observed in the given IANA time zone. */
 const zonedParts = (date: Date, timeZone: string): ZonedParts => {
   const parts: Record<string, string> = {}
   for (const part of zonedPartsFormatter(timeZone).formatToParts(date)) {
@@ -195,11 +186,9 @@ const zonedParts = (date: Date, timeZone: string): ZonedParts => {
     year: Number(parts.year),
     month: Number(parts.month),
     day: Number(parts.day),
-    // h23 still renders midnight as '24' in some engines, so fold it back to 0.
     hour: Number(parts.hour) % 24,
     minute: Number(parts.minute),
     second: Number(parts.second),
-    // Milliseconds are identical in every time zone, so read them straight off the instant.
     millisecond: date.getMilliseconds(),
   }
 }
@@ -210,14 +199,6 @@ const zoneOffsetMs = (date: Date, timeZone: string): number => {
   return asUtc - date.getTime()
 }
 
-/**
- * Re-expresses an absolute instant as a "wall clock" Date in the runtime's local zone whose
- * fields (getFullYear, getHours, …) read the same as a clock standing in `timeZone`.
- *
- * Passing no time zone returns the input unchanged, so an optional override can be threaded
- * through without branching. The result is only meant for reading or editing the displayed
- * fields; convert it back with {@link fromZonedDate} before exposing it as a real value again.
- */
 function toZonedDate(date: Date, timeZone?: string): Date
 function toZonedDate(date: null, timeZone?: string): null
 function toZonedDate(date: Date | null, timeZone?: string): Date | null
@@ -229,10 +210,6 @@ function toZonedDate(date: Date | null, timeZone?: string): Date | null {
   return new Date(parts.year, parts.month - 1, parts.day, parts.hour, parts.minute, parts.second, parts.millisecond)
 }
 
-/**
- * Inverse of {@link toZonedDate}: reads the local wall clock fields of `date` as if they were
- * a clock reading in `timeZone` and returns the matching absolute instant.
- */
 function fromZonedDate(date: Date, timeZone?: string): Date
 function fromZonedDate(date: null, timeZone?: string): null
 function fromZonedDate(date: Date | null, timeZone?: string): Date | null
@@ -244,7 +221,6 @@ function fromZonedDate(date: Date | null, timeZone?: string): Date | null {
     date.getFullYear(), date.getMonth(), date.getDate(),
     date.getHours(), date.getMinutes(), date.getSeconds(), date.getMilliseconds()
   )
-  // Two passes so a wall clock sitting next to a DST transition resolves to the correct offset.
   let offset = zoneOffsetMs(new Date(asUtc), timeZone)
   const refined = zoneOffsetMs(new Date(asUtc - offset), timeZone)
   if (refined !== offset) {
@@ -258,22 +234,20 @@ const weeksForCalenderMonth = (date: Date, weekStart: WeekDay, weeks: number = 6
   const year = date.getFullYear()
 
   const dayList: Date[] = []
-  let currentDate = new Date(year, month, 1) // Start of month
+  let currentDate = new Date(year, month, 1)
   const weekStartIndex = weekDayList.indexOf(weekStart)
 
-  // Move the current day to the week before
   while (currentDate.getDay() !== weekStartIndex) {
     currentDate = subtractDuration(currentDate, { days: 1 })
   }
 
   while (dayList.length < 7 * weeks) {
     const date = new Date(currentDate)
-    date.setHours(date.getHours(), date.getMinutes()) // To make sure we are not overwriting the time
+    date.setHours(date.getHours(), date.getMinutes())
     dayList.push(date)
     currentDate = addDuration(currentDate, { days: 1 })
   }
 
-  // weeks
   return equalSizeGroups(dayList, 7)
 }
 
@@ -411,8 +385,5 @@ export const DateUtils = {
   toInputString,
   tryParseDate,
   toOnlyDate: normalizeToDateOnly,
-  /**
-   * Normalizes a datetime by removing seconds and milliseconds.
-   */
   toDateTimeOnly: normalizeDatetime,
 }

--- a/stories/User Interaction/Input/DateTimeInput.stories.tsx
+++ b/stories/User Interaction/Input/DateTimeInput.stories.tsx
@@ -39,13 +39,13 @@ export const dateTimeInput: Story = {
     onValueChange: action('onValueChange'),
     onEditComplete: action('onEditComplete'),
   },
-  render: (args) => {
+  render: ({ is24HourFormat, timeZone, ...args }) => {
     const [value, setValue] = useState<Date | null>(args.initialValue ?? null)
     useEffect(() => {
       setValue(args.value ?? args.initialValue ?? null)
     }, [args.value, args.initialValue])
     return (
-      <LocaleContext.Provider value={{ locale: 'de-DE', setLocale: () => {} }}>
+      <LocaleContext.Provider value={{ locale: 'de-DE', setLocale: () => {}, is24HourFormat, timeZone: timeZone || undefined }}>
         <div className="flex-col-2 w-full max-w-md">
           <DateTimeInput
             {...args}
@@ -61,10 +61,10 @@ export const dateTimeInput: Story = {
           />
           <div className="flex-col-1 text-sm text-description">
             <pre>value = {value === null ? 'null' : value.toISOString()}</pre>
-            {value && args.timeZone && (
+            {value && timeZone && (
               <pre>
-                {`in ${args.timeZone} = ${new Intl.DateTimeFormat('de-DE', {
-                  timeZone: args.timeZone,
+                {`in ${timeZone} = ${new Intl.DateTimeFormat('de-DE', {
+                  timeZone,
                   dateStyle: 'short',
                   timeStyle: 'medium',
                 }).format(value)}`}

--- a/stories/User Interaction/Input/DateTimeInput.stories.tsx
+++ b/stories/User Interaction/Input/DateTimeInput.stories.tsx
@@ -5,8 +5,17 @@ import { DateTimeInput } from '@/src/components/user-interaction/input/DateTimeI
 import { TimeDisplay } from '@/src/components/user-interaction/date/TimeDisplay'
 import { LocaleContext } from '@/src/global-contexts/LocaleContext'
 
+const timeZones = ['', 'UTC', 'America/New_York', 'Europe/Berlin', 'Asia/Tokyo', 'Pacific/Kiritimati']
+
 const meta: Meta<typeof DateTimeInput> = {
   component: DateTimeInput,
+  argTypes: {
+    timeZone: {
+      control: 'select',
+      options: timeZones,
+      description: 'Display and edit the value in this IANA time zone. Empty uses the local zone.',
+    },
+  },
 }
 
 export default meta
@@ -24,6 +33,7 @@ export const dateTimeInput: Story = {
     secondIncrement: '1s',
     millisecondIncrement: '100ms',
     is24HourFormat: true,
+    timeZone: '',
     initialValue: null,
     value: undefined,
     onValueChange: action('onValueChange'),
@@ -51,6 +61,15 @@ export const dateTimeInput: Story = {
           />
           <div className="flex-col-1 text-sm text-description">
             <pre>value = {value === null ? 'null' : value.toISOString()}</pre>
+            {value && args.timeZone && (
+              <pre>
+                {`in ${args.timeZone} = ${new Intl.DateTimeFormat('de-DE', {
+                  timeZone: args.timeZone,
+                  dateStyle: 'short',
+                  timeStyle: 'medium',
+                }).format(value)}`}
+              </pre>
+            )}
             {value && <TimeDisplay date={value} mode="date"/>}
           </div>
         </div>

--- a/stories/User Interaction/Input/FlexibleDateTimeInput.stories.tsx
+++ b/stories/User Interaction/Input/FlexibleDateTimeInput.stories.tsx
@@ -39,13 +39,13 @@ export const flexibleDateTimeInput: Story = {
     onValueChange: action('onValueChange'),
     onEditComplete: action('onEditComplete'),
   },
-  render: (args) => {
+  render: ({ is24HourFormat, timeZone, ...args }) => {
     const [value, setValue] = useState<Date | null>(args.initialValue ?? null)
     useEffect(() => {
       setValue(args.value ?? args.initialValue ?? null)
     }, [args.value, args.initialValue])
     return (
-      <LocaleContext.Provider value={{ locale: 'de-DE', setLocale: () => {} }}>
+      <LocaleContext.Provider value={{ locale: 'de-DE', setLocale: () => {}, is24HourFormat, timeZone: timeZone || undefined }}>
         <div className="flex-col-2 w-full max-w-md">
           <FlexibleDateTimeInput
             {...args}
@@ -61,10 +61,10 @@ export const flexibleDateTimeInput: Story = {
           />
           <div className="flex-col-1 text-sm text-description">
             <pre>value = {value === null ? 'null' : value.toISOString()}</pre>
-            {value && args.timeZone && (
+            {value && timeZone && (
               <pre>
-                {`in ${args.timeZone} = ${new Intl.DateTimeFormat('de-DE', {
-                  timeZone: args.timeZone,
+                {`in ${timeZone} = ${new Intl.DateTimeFormat('de-DE', {
+                  timeZone,
                   dateStyle: 'short',
                   timeStyle: 'medium',
                 }).format(value)}`}

--- a/stories/User Interaction/Input/FlexibleDateTimeInput.stories.tsx
+++ b/stories/User Interaction/Input/FlexibleDateTimeInput.stories.tsx
@@ -5,8 +5,17 @@ import { FlexibleDateTimeInput } from '@/src/components/user-interaction/input/F
 import { TimeDisplay } from '@/src/components/user-interaction/date/TimeDisplay'
 import { LocaleContext } from '@/src/global-contexts/LocaleContext'
 
+const timeZones = ['', 'UTC', 'America/New_York', 'Europe/Berlin', 'Asia/Tokyo', 'Pacific/Kiritimati']
+
 const meta: Meta<typeof FlexibleDateTimeInput> = {
   component: FlexibleDateTimeInput,
+  argTypes: {
+    timeZone: {
+      control: 'select',
+      options: timeZones,
+      description: 'Display and edit the value in this IANA time zone. Empty uses the local zone.',
+    },
+  },
 }
 
 export default meta
@@ -24,6 +33,7 @@ export const flexibleDateTimeInput: Story = {
     secondIncrement: '1s',
     millisecondIncrement: '100ms',
     is24HourFormat: true,
+    timeZone: '',
     initialValue: null,
     value: undefined,
     onValueChange: action('onValueChange'),
@@ -51,6 +61,15 @@ export const flexibleDateTimeInput: Story = {
           />
           <div className="flex-col-1 text-sm text-description">
             <pre>value = {value === null ? 'null' : value.toISOString()}</pre>
+            {value && args.timeZone && (
+              <pre>
+                {`in ${args.timeZone} = ${new Intl.DateTimeFormat('de-DE', {
+                  timeZone: args.timeZone,
+                  dateStyle: 'short',
+                  timeStyle: 'medium',
+                }).format(value)}`}
+              </pre>
+            )}
             {value && <TimeDisplay date={value} mode="date"/>}
           </div>
         </div>

--- a/stories/User Interaction/Properties/DateProperty.stories.tsx
+++ b/stories/User Interaction/Properties/DateProperty.stories.tsx
@@ -23,10 +23,10 @@ export const dateProperty: Story = {
     onValueClear: action('onValueClear'),
   },
   render: ({ value, ...props }) => {
-    const [usedDate, setUsedDate] = useState<Date | undefined>(value)
+    const [usedDate, setUsedDate] = useState<Date | null>(value ?? null)
 
     useEffect(() => {
-      setUsedDate(value)
+      setUsedDate(value ?? null)
     }, [value])
 
     return (
@@ -43,7 +43,7 @@ export const dateProperty: Story = {
         }}
         onValueClear={() => {
           props.onValueClear?.()
-          setUsedDate(undefined)
+          setUsedDate(null)
         }}
       />
     )

--- a/tests/input/DateTimeField.test.tsx
+++ b/tests/input/DateTimeField.test.tsx
@@ -130,6 +130,31 @@ describe('DateTimeField', () => {
     expect(document.activeElement).toBe(month)
   })
 
+  test('does not complete editing while focus moves to another segment', () => {
+    const frames: FrameRequestCallback[] = []
+    const raf = jest.spyOn(window, 'requestAnimationFrame').mockImplementation((callback) => {
+      frames.push(callback)
+      return frames.length
+    })
+    try {
+      const onEditComplete = jest.fn()
+      renderField({ onEditComplete })
+      const [day, month] = screen.getAllByRole('spinbutton')
+
+      act(() => day.focus())
+      // Reproduce the real-browser race: focus is heading to the month (same field) but momentarily
+      // sits on <body>, while the blur still reports the month as the related target.
+      act(() => day.blur())
+      frames.length = 0
+      act(() => fireEvent.focusOut(day, { relatedTarget: month }))
+      act(() => frames.forEach(frame => frame(0)))
+
+      expect(onEditComplete).not.toHaveBeenCalled()
+    } finally {
+      raf.mockRestore()
+    }
+  })
+
   test('normalizes a shorthand year to the stored full year on blur', () => {
     const frames: FrameRequestCallback[] = []
     const raf = jest.spyOn(window, 'requestAnimationFrame').mockImplementation((callback) => {

--- a/tests/input/DateTimeField.test.tsx
+++ b/tests/input/DateTimeField.test.tsx
@@ -226,6 +226,38 @@ describe('DateTimeInput controlled value', () => {
   })
 })
 
+describe('DateTimeInput hour format', () => {
+  test('defaults to a 24 hour clock regardless of locale', () => {
+    render(
+      <LocaleContext.Provider value={{ locale: 'en-US', setLocale: () => {} }}>
+        <DateTimeInput mode="time" initialValue={new Date(2024, 0, 1, 18, 30)} />
+      </LocaleContext.Provider>
+    )
+
+    expect(screen.getAllByRole('spinbutton').map(segment => segment.textContent)).toEqual(['18', '30'])
+  })
+
+  test('uses a 12 hour clock when the context opts out', () => {
+    render(
+      <LocaleContext.Provider value={{ locale: 'en-US', setLocale: () => {}, is24HourFormat: false }}>
+        <DateTimeInput mode="time" initialValue={new Date(2024, 0, 1, 18, 30)} />
+      </LocaleContext.Provider>
+    )
+
+    expect(screen.getAllByRole('spinbutton').map(segment => segment.textContent)).toEqual(['06', '30', 'PM'])
+  })
+
+  test('an explicit is24HourFormat prop overrides the context', () => {
+    render(
+      <LocaleContext.Provider value={{ locale: 'en-US', setLocale: () => {}, is24HourFormat: false }}>
+        <DateTimeInput mode="time" is24HourFormat={true} initialValue={new Date(2024, 0, 1, 18, 30)} />
+      </LocaleContext.Provider>
+    )
+
+    expect(screen.getAllByRole('spinbutton').map(segment => segment.textContent)).toEqual(['18', '30'])
+  })
+})
+
 describe('DateTimeInput time zone', () => {
   test('reads the display zone from the locale context', () => {
     render(

--- a/tests/input/DateTimeField.test.tsx
+++ b/tests/input/DateTimeField.test.tsx
@@ -142,8 +142,6 @@ describe('DateTimeField', () => {
       const [day, month] = screen.getAllByRole('spinbutton')
 
       act(() => day.focus())
-      // Reproduce the real-browser race: focus is heading to the month (same field) but momentarily
-      // sits on <body>, while the blur still reports the month as the related target.
       act(() => day.blur())
       frames.length = 0
       act(() => fireEvent.focusOut(day, { relatedTarget: month }))
@@ -225,6 +223,39 @@ describe('DateTimeInput controlled value', () => {
     expect(screen.getAllByRole('spinbutton').map(segment => segment.textContent)).toEqual(['06', '15', '2026'])
     const committed = onValueChange.mock.calls.at(-1)![0] as Date
     expect([committed.getMonth(), committed.getDate(), committed.getFullYear()]).toEqual([5, 15, 2026])
+  })
+})
+
+describe('DateTimeInput time zone', () => {
+  test('reads the display zone from the locale context', () => {
+    render(
+      <LocaleContext.Provider value={{ locale: 'en-US', setLocale: () => {}, timeZone: 'America/New_York' }}>
+        <DateTimeInput
+          mode="dateTime"
+          is24HourFormat={true}
+          initialValue={new Date(Date.UTC(2024, 5, 1, 2, 30))}
+        />
+      </LocaleContext.Provider>
+    )
+
+    expect(screen.getAllByRole('spinbutton').map(segment => segment.textContent))
+      .toEqual(['05', '31', '2024', '22', '30'])
+  })
+
+  test('an explicit timeZone prop overrides the context', () => {
+    render(
+      <LocaleContext.Provider value={{ locale: 'en-US', setLocale: () => {}, timeZone: 'America/New_York' }}>
+        <DateTimeInput
+          mode="dateTime"
+          is24HourFormat={true}
+          timeZone="UTC"
+          initialValue={new Date(Date.UTC(2024, 5, 1, 2, 30))}
+        />
+      </LocaleContext.Provider>
+    )
+
+    expect(screen.getAllByRole('spinbutton').map(segment => segment.textContent))
+      .toEqual(['06', '01', '2024', '02', '30'])
   })
 })
 

--- a/tests/input/FlexibleDateTimeInput.test.tsx
+++ b/tests/input/FlexibleDateTimeInput.test.tsx
@@ -2,7 +2,7 @@
  * @jest-environment jsdom
  */
 import { useState } from 'react'
-import { fireEvent, render, screen } from '@testing-library/react'
+import { act, fireEvent, render, screen } from '@testing-library/react'
 import { LocaleContext } from '../../src/global-contexts/LocaleContext'
 import { FlexibleDateTimeInput, type FlexibleDateTimeInputProps } from '../../src/components/user-interaction/input/FlexibleDateTimeInput'
 
@@ -30,6 +30,11 @@ const renderFlexible = (props: Partial<FlexibleDateTimeInputProps> & { defaultMo
 const toggleMode = () => fireEvent.click(screen.getAllByRole('button')[0])
 const segmentCount = () => screen.getAllByRole('spinbutton').length
 const lastValue = (mock: jest.Mock): Date => mock.mock.calls.at(-1)![0] as Date
+const typeInto = (segment: HTMLElement, digits: string) => {
+  for (const digit of digits) {
+    fireEvent.keyDown(segment, { key: digit })
+  }
+}
 
 describe('FlexibleDateTimeInput mode toggle', () => {
   test('date to date time without a value reveals the time segments', () => {
@@ -71,6 +76,18 @@ describe('FlexibleDateTimeInput mode toggle', () => {
     expect(segmentCount()).toBe(3)
     const committed = lastValue(onValueChange)
     expect([committed.getHours(), committed.getMinutes(), committed.getSeconds(), committed.getMilliseconds()]).toEqual([23, 59, 59, 999])
+  })
+
+  test('lets a full year be typed over an existing value without snapping to the 1900s', () => {
+    const { onValueChange } = renderFlexible({ defaultMode: 'date', initialValue: new Date(2026, 0, 1, 23, 59, 59, 999) })
+    // German order is day, month, year.
+    const year = screen.getAllByRole('spinbutton')[2]
+
+    act(() => year.focus())
+    typeInto(year, '2004')
+
+    expect(screen.getAllByRole('spinbutton')[2].textContent).toBe('2004')
+    expect(lastValue(onValueChange).getFullYear()).toBe(2004)
   })
 
   test('uses 24 hour time without a day period for German', () => {

--- a/tests/input/FlexibleDateTimeInput.test.tsx
+++ b/tests/input/FlexibleDateTimeInput.test.tsx
@@ -80,7 +80,6 @@ describe('FlexibleDateTimeInput mode toggle', () => {
 
   test('lets a full year be typed over an existing value without snapping to the 1900s', () => {
     const { onValueChange } = renderFlexible({ defaultMode: 'date', initialValue: new Date(2026, 0, 1, 23, 59, 59, 999) })
-    // German order is day, month, year.
     const year = screen.getAllByRole('spinbutton')[2]
 
     act(() => year.focus())

--- a/tests/time/timeZone.test.ts
+++ b/tests/time/timeZone.test.ts
@@ -2,7 +2,6 @@ import { DateUtils } from '../../src/utils/date'
 
 describe('DateUtils time zone conversion', () => {
   test('reads the wall clock fields of an instant in a given zone', () => {
-    // 2024-06-01T00:30:00Z is still 2024-05-31 in New York (UTC-4 in summer).
     const instant = new Date(Date.UTC(2024, 5, 1, 0, 30, 0))
     const parts = DateUtils.zonedParts(instant, 'America/New_York')
     expect([parts.year, parts.month, parts.day, parts.hour, parts.minute]).toEqual([2024, 5, 31, 20, 30])

--- a/tests/time/timeZone.test.ts
+++ b/tests/time/timeZone.test.ts
@@ -1,0 +1,38 @@
+import { DateUtils } from '../../src/utils/date'
+
+describe('DateUtils time zone conversion', () => {
+  test('reads the wall clock fields of an instant in a given zone', () => {
+    // 2024-06-01T00:30:00Z is still 2024-05-31 in New York (UTC-4 in summer).
+    const instant = new Date(Date.UTC(2024, 5, 1, 0, 30, 0))
+    const parts = DateUtils.zonedParts(instant, 'America/New_York')
+    expect([parts.year, parts.month, parts.day, parts.hour, parts.minute]).toEqual([2024, 5, 31, 20, 30])
+  })
+
+  test('toZonedDate exposes the zone wall clock through the local Date getters', () => {
+    const instant = new Date(Date.UTC(2024, 5, 1, 0, 30, 0))
+    const zoned = DateUtils.toZonedDate(instant, 'America/New_York')!
+    expect([zoned.getFullYear(), zoned.getMonth(), zoned.getDate(), zoned.getHours(), zoned.getMinutes()])
+      .toEqual([2024, 4, 31, 20, 30])
+  })
+
+  test('toZonedDate and fromZonedDate are inverses across zones and DST', () => {
+    const instants = [
+      new Date(Date.UTC(2024, 0, 15, 12, 0, 0)),
+      new Date(Date.UTC(2024, 5, 1, 0, 30, 0)),
+      new Date(Date.UTC(2024, 6, 20, 23, 45, 30, 123)),
+    ]
+    for (const zone of ['UTC', 'America/New_York', 'Asia/Tokyo', 'Europe/Berlin']) {
+      for (const instant of instants) {
+        const roundTripped = DateUtils.fromZonedDate(DateUtils.toZonedDate(instant, zone), zone)
+        expect(roundTripped.getTime()).toBe(instant.getTime())
+      }
+    }
+  })
+
+  test('passes the value through untouched without a zone', () => {
+    const instant = new Date(Date.UTC(2024, 5, 1, 0, 30, 0))
+    expect(DateUtils.toZonedDate(instant, undefined)).toBe(instant)
+    expect(DateUtils.fromZonedDate(instant, undefined)).toBe(instant)
+    expect(DateUtils.toZonedDate(null, 'America/New_York')).toBeNull()
+  })
+})


### PR DESCRIPTION
## Summary
This PR adds comprehensive time zone support to `DateTimeInput` and `FlexibleDateTimeInput` components, allowing users to display and edit dates/times as they appear in a specific IANA time zone while maintaining an absolute `Date` value contract.

## Key Changes

- **New time zone utilities in `DateUtils`**:
  - `zonedParts()`: Extracts wall clock fields (year, month, day, hour, etc.) for a given time zone using `Intl.DateTimeFormat`
  - `toZonedDate()`: Converts an absolute instant to a local Date whose fields read as the wall clock in a specified time zone
  - `fromZonedDate()`: Inverse operation that interprets local Date fields as a wall clock reading in a specified time zone and returns the absolute instant
  - Includes caching of `Intl.DateTimeFormat` instances for performance and proper DST handling with two-pass offset calculation

- **DateTimeInput enhancements**:
  - New optional `timeZone` prop to display/edit values in a specific IANA time zone
  - Internal conversion layer that transforms values to/from the specified zone for display while keeping the public API contract unchanged
  - Zone conversion applied to both the text field and picker dialog

- **FlexibleDateTimeInput updates**:
  - Passes through `timeZone` prop to underlying `DateTimeInput`
  - Adjusts "fixed time" anchor comparisons to work in the display zone rather than local zone

- **DateTimeField improvements**:
  - Prevents overwriting segments mid-entry (while a buffer is held)
  - Defers committing partial year entries to avoid emitting invalid dates like "0002" or "1902" during typing
  - Expands shorthand years on blur using existing arrow-stepping logic

- **Test coverage**:
  - New `timeZone.test.ts` with comprehensive tests for zone conversions, DST handling, and round-trip consistency across multiple time zones
  - Updated `FlexibleDateTimeInput.test.ts` with test for full year typing without snapping to 1900s

- **Storybook updates**:
  - Added `timeZone` control to both `DateTimeInput` and `FlexibleDateTimeInput` stories with common IANA zones for interactive testing

## Implementation Details

- Time zone conversions use the standard `Intl.DateTimeFormat` API for reliability and broad browser support
- The implementation maintains backward compatibility: omitting the `timeZone` prop uses the local zone as before
- DST transitions are handled correctly through a two-pass offset calculation in `fromZonedDate()`
- Milliseconds are read directly from the instant since they're identical across all time zones
- The `h23` hour cycle is used to normalize midnight representation across different JavaScript engines

https://claude.ai/code/session_01HW8Uw1XGkfZSb6FwpYNSAS