### PR TITLE
Convert React to peer dependency in package.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.10.3] - 2026-06-24
+
+### Fixed
+- push `react` as peer dependency only
+
 ## [0.10.2] - 2026-06-16
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@helpwave/hightide",
-  "version": "0.10.1",
+  "version": "0.10.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@helpwave/hightide",
-      "version": "0.10.1",
+      "version": "0.10.3",
       "license": "MPL-2.0",
       "dependencies": {
         "@helpwave/internationalization": "0.4.0",
@@ -15,8 +15,6 @@
         "@tanstack/react-table": "8.21.3",
         "clsx": "2.1.1",
         "lucide-react": "0.561.0",
-        "react": "19.2.3",
-        "react-dom": "19.2.3",
         "tailwindcss": "4.1.18"
       },
       "bin": {
@@ -46,11 +44,17 @@
         "jest": "30.2.0",
         "jest-environment-jsdom": "30.2.0",
         "postcss": "8.5.15",
+        "react": "19.2.3",
+        "react-dom": "19.2.3",
         "storybook": "10.4.5",
         "ts-jest": "29.4.6",
         "tsup": "8.5.1",
         "typescript": "5.7.2",
         "vite": "7.3.5"
+      },
+      "peerDependencies": {
+        "react": "^19.0.0",
+        "react-dom": "^19.0.0"
       }
     },
     "node_modules/@adobe/css-tools": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "access": "public"
   },
   "license": "MPL-2.0",
-  "version": "0.10.2",
+  "version": "0.10.3",
   "files": [
     "dist"
   ],
@@ -47,9 +47,11 @@
     "@tanstack/react-table": "8.21.3",
     "clsx": "2.1.1",
     "lucide-react": "0.561.0",
-    "react": "19.2.3",
-    "react-dom": "19.2.3",
     "tailwindcss": "4.1.18"
+  },
+  "peerDependencies": {
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0"
   },
   "devDependencies": {
     "@babel/core": "7.26.0",
@@ -75,6 +77,8 @@
     "jest": "30.2.0",
     "jest-environment-jsdom": "30.2.0",
     "postcss": "8.5.15",
+    "react": "19.2.3",
+    "react-dom": "19.2.3",
     "storybook": "10.4.5",
     "ts-jest": "29.4.6",
     "tsup": "8.5.1",


### PR DESCRIPTION
## Summary
This change converts React and React DOM from direct dependencies to peer dependencies, while moving them to devDependencies for development and testing purposes.

## Key Changes
- Moved `react` and `react-dom` from `dependencies` to `peerDependencies` with `^19.0.0` version range
- Added `react` and `react-dom` to `devDependencies` at version `19.2.3` for local development and testing

## Rationale
This is a common pattern for component libraries and packages that are meant to be used within React applications. By making React a peer dependency, consumers of this package are responsible for providing their own React installation, which:
- Avoids duplicate React installations in consuming applications
- Allows consumers to use compatible React versions they prefer
- Reduces bundle size for applications using this package
- Maintains React as available for development and testing via devDependencies

https://claude.ai/code/session_01PjdMFFJTeZktVZ5bKyqmK2