### PR TITLE
feat(table): opt-in row virtualization (windowing)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.11.0] - 2026-06-24
+
+### Added
+- Opt-in row virtualization (windowing) for the table via a new `virtualized` prop on `TableDisplay` (and through `Table`/`TableWithSelection` `displayProps`). Only the rows in (or near) the viewport are mounted to the DOM, keeping large, infinitely-scrolled lists responsive. Accepts `true` or `{ estimateRowHeight, overscan, scroll }`, where `scroll` is `'window'` (default, tracks the page scroll) or `'container'` (tracks the table container's own scroll). Rows stay in normal table flow via spacer rows, so column sizing/resizing, the sticky header, sorting, filtering, selection and row clicks are preserved; per-row heights are measured to support variable-height rows. Filler rows are ignored while virtualized.
+- `@tanstack/react-virtual` dependency.
+
 ## [0.10.3] - 2026-06-24
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,19 @@
 {
   "name": "@helpwave/hightide",
-  "version": "0.10.3",
+  "version": "0.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@helpwave/hightide",
-      "version": "0.10.3",
+      "version": "0.11.0",
       "license": "MPL-2.0",
       "dependencies": {
         "@helpwave/internationalization": "0.4.0",
         "@radix-ui/react-slot": "1.2.4",
         "@tailwindcss/cli": "4.1.18",
         "@tanstack/react-table": "8.21.3",
+        "@tanstack/react-virtual": "3.14.3",
         "clsx": "2.1.1",
         "lucide-react": "0.561.0",
         "tailwindcss": "4.1.18"
@@ -6943,6 +6944,23 @@
         "react-dom": ">=16.8"
       }
     },
+    "node_modules/@tanstack/react-virtual": {
+      "version": "3.14.3",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.14.3.tgz",
+      "integrity": "sha512-k/cnHPVaOfn46hSbiY6n4Dzf4QjCGWSF40zR5QIIYUqPAjpA6TN7InfYmcMiDVQGP2iUn9xsRbAl8u1v3UmeVQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/virtual-core": "3.17.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/@tanstack/table-core": {
       "version": "8.21.3",
       "resolved": "https://registry.npmjs.org/@tanstack/table-core/-/table-core-8.21.3.tgz",
@@ -6951,6 +6969,16 @@
       "engines": {
         "node": ">=12"
       },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/virtual-core": {
+      "version": "3.17.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.17.1.tgz",
+      "integrity": "sha512-VZyW2Uiml5tmBZwPGrSD3Sz73OxzljQMCmzYHsUTPEuTsERf5xwa+uWb01xEzkz3ZSYTjj8NEb/mKHvgKxyZdA==",
+      "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/tannerlinsley"

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "access": "public"
   },
   "license": "MPL-2.0",
-  "version": "0.10.3",
+  "version": "0.11.0",
   "files": [
     "dist"
   ],
@@ -45,6 +45,7 @@
     "@radix-ui/react-slot": "1.2.4",
     "@tailwindcss/cli": "4.1.18",
     "@tanstack/react-table": "8.21.3",
+    "@tanstack/react-virtual": "3.14.3",
     "clsx": "2.1.1",
     "lucide-react": "0.561.0",
     "tailwindcss": "4.1.18"

--- a/src/components/layout/table/TableDisplay.tsx
+++ b/src/components/layout/table/TableDisplay.tsx
@@ -4,10 +4,22 @@ import { TableBody } from './TableBody'
 import type { TableHeaderProps } from './TableHeader'
 import { TableHeader } from './TableHeader'
 import { useTableContainerContext, useTableStateContext } from './TableContext'
+import type { TableVirtualizationOptions } from './VirtualizedTableBody'
+import { VirtualizedTableBody } from './VirtualizedTableBody'
 
 export interface TableDisplayProps extends TableHTMLAttributes<HTMLTableElement> {
   containerProps?: Omit<React.HTMLAttributes<HTMLDivElement>, 'children'>,
   tableHeaderProps?: Omit<TableHeaderProps, 'children' | 'table'>,
+  /**
+   * Opt into row virtualization (windowing): only the rows in (or near) the viewport are mounted to
+   * the DOM, so very large lists stay responsive. Pass `true` for the defaults or an options object
+   * to tune it (see {@link TableVirtualizationOptions}). Defaults to window-scroll, which drops into
+   * page-scrolled / infinite-scroll layouts without any change.
+   *
+   * Filler rows are ignored while virtualized (the reserved scroll height already fills the table),
+   * so `isUsingFillerRows` has no effect in this mode. Defaults to `false` (unchanged behaviour).
+   */
+  virtualized?: boolean | TableVirtualizationOptions,
 }
 
 
@@ -18,6 +30,7 @@ export const TableDisplay = <T,>({
   children,
   containerProps,
   tableHeaderProps,
+  virtualized = false,
   ...props
 }: TableDisplayProps) => {
   const { table } = useTableStateContext<T>()
@@ -36,7 +49,9 @@ export const TableDisplay = <T,>({
       >
         {children}
         <TableHeader {...tableHeaderProps} />
-        <TableBody />
+        {virtualized
+          ? <VirtualizedTableBody {...(typeof virtualized === 'object' ? virtualized : {})} />
+          : <TableBody />}
       </table>
     </div>
   )

--- a/src/components/layout/table/VirtualizedTableBody.tsx
+++ b/src/components/layout/table/VirtualizedTableBody.tsx
@@ -1,0 +1,141 @@
+import type { Key } from 'react'
+import { useEffect, useRef, useState } from 'react'
+import type { Row } from '@tanstack/react-table'
+import { flexRender } from '@tanstack/react-table'
+import { useVirtualizer, useWindowVirtualizer } from '@tanstack/react-virtual'
+import clsx from 'clsx'
+import { useTableContainerContext, useTableStateWithoutSizingContext } from './TableContext'
+import { PropsUtil } from '@/src/utils/propsUtil'
+import { BagFunctionUtil } from '@/src/utils/bagFunctions'
+
+export type TableVirtualizationOptions = {
+  /** Estimated row height in px, refined by measurement once rows mount. Default `48`. */
+  estimateRowHeight?: number,
+  /** Rows rendered above and below the viewport to avoid blank space while scrolling. Default `8`. */
+  overscan?: number,
+  /**
+   * Which scroll context to track:
+   * - `'window'` (default) windows against the page/document scroll. Use this when the list
+   *   scrolls with the page (e.g. a document-scroll infinite list with a sentinel below the table).
+   * - `'container'` windows against the table container's own scroll. The container
+   *   (`data-name="table-container"`) needs a bounded height and `overflow-y: auto` for this.
+   */
+  scroll?: 'window' | 'container',
+}
+
+export type VirtualizedTableBodyProps = TableVirtualizationOptions
+
+/**
+ * Drop-in replacement for {@link TableBody} that only mounts the visible rows (plus a small
+ * overscan) instead of the whole row model. Rows stay in normal table flow — a single spacer
+ * `<tr>` above and below the window reserves the scroll height — so column sizing (driven by the
+ * `<colgroup>`), the sticky header, resizing, sorting/filtering, selection and row clicks all keep
+ * working unchanged. Per-row heights are measured, so variable-height rows are supported.
+ *
+ * Filler rows are intentionally ignored here: virtualization already reserves the full scroll
+ * height, so `isUsingFillerRows` is a no-op while virtualized.
+ */
+export const VirtualizedTableBody = ({
+  estimateRowHeight = 48,
+  overscan = 8,
+  scroll = 'window',
+}: VirtualizedTableBodyProps) => {
+  const { table, onRowClick } = useTableStateWithoutSizingContext<unknown>()
+  const { containerRef } = useTableContainerContext<unknown>()
+  const rows = table.getRowModel().rows
+
+  const bodyRef = useRef<HTMLTableSectionElement | null>(null)
+  const [isMounted, setIsMounted] = useState(false)
+  const [scrollMargin, setScrollMargin] = useState(0)
+
+  useEffect(() => setIsMounted(true), [])
+
+  // In window mode the virtualizer needs the body's offset from the top of the document so it can
+  // map window scroll -> row positions. That offset only moves when layout above the table changes
+  // (resize), not when rows are appended below, so we track it via a ResizeObserver/resize listener
+  // and keep the dependency list narrow rather than recomputing on every row-count change.
+  useEffect(() => {
+    if (scroll !== 'window') return
+    const element = bodyRef.current
+    if (!element || typeof window === 'undefined') return
+    const measure = () => {
+      const next = element.getBoundingClientRect().top + window.scrollY
+      setScrollMargin(prev => (Math.abs(prev - next) < 1 ? prev : next))
+    }
+    measure()
+    const resizeObserver = new ResizeObserver(measure)
+    resizeObserver.observe(element)
+    window.addEventListener('resize', measure)
+    return () => {
+      resizeObserver.disconnect()
+      window.removeEventListener('resize', measure)
+    }
+  }, [scroll])
+
+  const common = {
+    count: rows.length,
+    estimateSize: () => estimateRowHeight,
+    overscan,
+    getItemKey: (index: number) => rows[index]?.id ?? index,
+  }
+  // Hooks must run unconditionally; we just pick which result to use based on `scroll`.
+  const windowVirtualizer = useWindowVirtualizer({ ...common, scrollMargin })
+  const containerVirtualizer = useVirtualizer({ ...common, getScrollElement: () => containerRef.current })
+  const virtualizer = scroll === 'window' ? windowVirtualizer : containerVirtualizer
+  const offset = scroll === 'window' ? scrollMargin : 0
+
+  const renderRow = (row: Row<unknown>, key: Key, measured: boolean, dataIndex?: number) => (
+    <tr
+      key={key}
+      data-index={dataIndex}
+      ref={measured ? virtualizer.measureElement : undefined}
+      onClick={() => onRowClick?.(row, table)}
+      data-clickable={PropsUtil.dataAttributes.bool(!!onRowClick)}
+      data-name="table-body-row"
+      className={clsx(BagFunctionUtil.resolve(table.options.meta?.bodyRowClassName, row.original))}
+    >
+      {row.getVisibleCells().map(cell => (
+        <td key={cell.id} data-name="table-body-cell" className={clsx(cell.column.columnDef.meta?.className)}>
+          {flexRender(cell.column.columnDef.cell, cell.getContext())}
+        </td>
+      ))}
+    </tr>
+  )
+
+  // Before mount, render the rows in plain flow (no windowing). The window virtualizer produces an
+  // empty range until it has measured the scroll position, so gating here avoids an SSR/hydration
+  // mismatch. Consumers that fetch rows client-side render nothing here anyway.
+  if (!isMounted) {
+    return (
+      <tbody ref={bodyRef}>
+        {rows.map(row => renderRow(row, row.id, false))}
+      </tbody>
+    )
+  }
+
+  const items = virtualizer.getVirtualItems()
+  const total = virtualizer.getTotalSize()
+  const paddingTop = items.length ? items[0].start - offset : 0
+  const paddingBottom = items.length ? total - (items[items.length - 1].end - offset) : 0
+  const columnCount = Math.max(1, table.getVisibleLeafColumns().length)
+
+  return (
+    <tbody ref={bodyRef}>
+      {paddingTop > 0 && (
+        <tr aria-hidden="true">
+          <td colSpan={columnCount} style={{ height: paddingTop, padding: 0, border: 0 }}/>
+        </tr>
+      )}
+      {items.map(virtualRow => {
+        const row = rows[virtualRow.index]
+        if (!row) return null
+        return renderRow(row, virtualRow.key, true, virtualRow.index)
+      })}
+      {paddingBottom > 0 && (
+        <tr aria-hidden="true">
+          <td colSpan={columnCount} style={{ height: paddingBottom, padding: 0, border: 0 }}/>
+        </tr>
+      )}
+    </tbody>
+  )
+}

--- a/stories/Layout/Table/VirtualizedInfiniteScrolling.stories.tsx
+++ b/stories/Layout/Table/VirtualizedInfiniteScrolling.stories.tsx
@@ -1,0 +1,169 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { faker } from '@faker-js/faker'
+import { range } from '@/src/utils/array'
+import { Table } from '@/src/components/layout/table/Table'
+import { TableColumn } from '@/src/components/layout/table/TableColumn'
+import { TableCell } from '@/src/components/layout/table/TableCell'
+import { TableColumnSwitcher } from '@/src/components/layout/table/TableColumnSwitcher'
+import { Chip } from '@/src/components/display-and-visualization/Chip'
+import { useHightideTranslation } from '@/src/i18n/useHightideTranslation'
+
+/*
+ * Mirrors the TanStack "virtualized infinite scrolling" example
+ * (https://tanstack.com/table/v8/docs/framework/react/examples/virtualized-infinite-scrolling)
+ * against hightide's table: a large, paginated-on-scroll list where only the visible rows are
+ * mounted to the DOM via the `virtualized` prop. Rendered in `container` scroll mode (a bounded,
+ * internally-scrolling table with a sticky header), so the whole demo is self-contained.
+ *
+ * Open the elements panel while scrolling: the `<tbody>` only ever holds the visible rows plus a
+ * small overscan, regardless of how many rows have been fetched.
+ */
+
+type Person = {
+  id: string,
+  name: string,
+  age: number,
+  email: string,
+  city: string,
+  status: 'active' | 'inactive' | 'pending',
+  visits: number,
+  joined: Date,
+}
+
+const statuses = ['active', 'inactive', 'pending'] as const
+
+// Deterministic data so the story looks the same on every load.
+faker.seed(20260624)
+
+const TOTAL_ROWS = 5000
+const FETCH_SIZE = 50
+
+const allRows: Person[] = range(TOTAL_ROWS).map((index) => ({
+  id: String(index + 1),
+  name: faker.person.fullName(),
+  age: faker.number.int({ min: 18, max: 99 }),
+  email: faker.internet.email(),
+  city: faker.location.city(),
+  status: faker.helpers.arrayElement(statuses),
+  visits: faker.number.int({ min: 0, max: 1000 }),
+  joined: faker.date.past({ years: 10 }),
+}))
+
+// Pretend backend: returns one page after a short delay.
+const fetchPage = async (pageIndex: number): Promise<Person[]> => {
+  await new Promise((resolve) => setTimeout(resolve, 600))
+  const start = pageIndex * FETCH_SIZE
+  return allRows.slice(start, start + FETCH_SIZE)
+}
+
+// 500px from the bottom we kick off the next page.
+const BOTTOM_THRESHOLD_PX = 500
+
+const meta: Meta = {}
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const virtualizedInfiniteScrolling: Story = {
+  render: () => {
+    const translation = useHightideTranslation()
+
+    const [pages, setPages] = useState<Person[][]>([])
+    const [isFetching, setIsFetching] = useState(false)
+    const isFetchingRef = useRef(false)
+    const loadedPagesRef = useRef(0)
+
+    const flatData = useMemo(() => pages.flat(), [pages])
+    const totalFetched = flatData.length
+
+    const fetchNextPage = useCallback(async () => {
+      if (isFetchingRef.current) return
+      if (loadedPagesRef.current * FETCH_SIZE >= TOTAL_ROWS) return
+      isFetchingRef.current = true
+      setIsFetching(true)
+      const pageIndex = loadedPagesRef.current
+      const rows = await fetchPage(pageIndex)
+      setPages((prev) => [...prev, rows])
+      loadedPagesRef.current = pageIndex + 1
+      isFetchingRef.current = false
+      setIsFetching(false)
+    }, [])
+
+    // Load the first page on mount; the rest stream in as the user scrolls.
+    useEffect(() => {
+      void fetchNextPage()
+    }, [fetchNextPage])
+
+    const fetchMoreOnBottomReached = useCallback((element: HTMLDivElement | null) => {
+      if (!element) return
+      const { scrollHeight, scrollTop, clientHeight } = element
+      if (scrollHeight - scrollTop - clientHeight < BOTTOM_THRESHOLD_PX && !isFetchingRef.current && totalFetched < TOTAL_ROWS) {
+        void fetchNextPage()
+      }
+    }, [fetchNextPage, totalFetched])
+
+    return (
+      <Table
+        table={{
+          data: flatData,
+          // Virtualization reserves the full scroll height itself, so filler rows are unnecessary,
+          // and we put every fetched row into a single page so they are all available to window.
+          isUsingFillerRows: false,
+          initialState: { pagination: { pageIndex: 0, pageSize: TOTAL_ROWS } },
+        }}
+        paginationOptions={{ showPagination: false }}
+        displayProps={{
+          virtualized: { scroll: 'container', estimateRowHeight: 48 },
+          tableHeaderProps: { isSticky: true },
+          containerProps: {
+            className: 'max-h-[600px]',
+            onScroll: (event) => fetchMoreOnBottomReached(event.currentTarget),
+          },
+        }}
+        header={(
+          <div className="flex-row-2 items-center justify-between w-full">
+            <span className="typography-title-md">Virtualized infinite scrolling</span>
+            <div className="flex-row-2 items-center">
+              <span className="text-description typography-label-md">{`${totalFetched} of ${TOTAL_ROWS} rows loaded`}</span>
+              <TableColumnSwitcher/>
+            </div>
+          </div>
+        )}
+        footer={isFetching ? (
+          <span className="text-description typography-label-md">Fetching more…</span>
+        ) : null}
+      >
+        <TableColumn id="id" header="ID" accessorKey="id" sortingFn="alphanumeric" size={80} minSize={70} maxSize={120}/>
+        <TableColumn id="name" header={translation('name')} accessorKey="name" sortingFn="text" size={200} minSize={160} maxSize={320} filterType="text"/>
+        <TableColumn id="age" header={translation('age')} accessorKey="age" sortingFn="alphanumeric" size={110} minSize={90} maxSize={160} filterType="number"/>
+        <TableColumn id="email" header="Email" accessorKey="email" sortingFn="text" size={280} minSize={200} maxSize={400} filterType="text"/>
+        <TableColumn id="city" header="City" accessorKey="city" sortingFn="text" size={180} minSize={140} maxSize={300} filterType="text"/>
+        <TableColumn
+          id="status"
+          header="Status"
+          accessorKey="status"
+          sortingFn="text"
+          size={150}
+          minSize={120}
+          maxSize={220}
+          filterType="singleTag"
+          cell={({ cell }) => (<Chip>{cell.getValue() as string}</Chip>)}
+          meta={{ filterData: { tags: statuses.map((status) => ({ tag: status, label: status })) } }}
+        />
+        <TableColumn id="visits" header="Visits" accessorKey="visits" sortingFn="alphanumeric" size={120} minSize={100} maxSize={180} filterType="number"/>
+        <TableColumn
+          id="joined"
+          header="Joined"
+          accessorKey="joined"
+          sortingFn="datetime"
+          size={200}
+          minSize={160}
+          maxSize={300}
+          filterType="date"
+          cell={({ cell }) => (<TableCell>{(cell.getValue() as Date).toLocaleDateString()}</TableCell>)}
+        />
+      </Table>
+    )
+  },
+}

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -15,6 +15,7 @@ export default defineConfig({
     'react-dom',
     'clsx',
     '@tanstack/react-table',
+    '@tanstack/react-virtual',
     'lucide-react',
     'radix-ui',
     'react-custom-scrollbars-2',


### PR DESCRIPTION
## Motivation

`helpwave/tasks` renders the Patient/Task **table** views as large, infinitely-scrolled lists. Today every row mounts to the DOM, which gets heavy with hundreds/thousands of rows. The card views are already windowed in the app, but the tables render through hightide's `TableDisplay`, which had no virtualization seam. This adds that seam in the design system so the app can opt in.

## What this does

Adds an opt-in `virtualized` prop to `TableDisplay` (also reachable through `Table` / `TableWithSelection` via `displayProps`). When enabled, only the rows in (or near) the viewport are mounted:

```tsx
<TableProvider data={rows} columns={columns} state={...}>
  <TableDisplay virtualized />               {/* defaults: window scroll */}
</TableProvider>

<TableDisplay virtualized={{ estimateRowHeight: 56, overscan: 12, scroll: 'container' }} />
```

### Why padding rows (not absolute positioning)
hightide tables use `table-fixed` layout with a `<colgroup>` driving column widths. A `display:grid`/absolute-positioned rewrite (as in some TanStack examples) would break that sizing, the resize handles, and the theme CSS. Instead, the new `VirtualizedTableBody` keeps rows in **normal table flow** and reserves the scroll height with a single spacer `<tr>` above and below the window. Because columns have explicit `size`, widths don't reflow as rows enter/leave. `measureElement` + `data-index` still give accurate per-row heights for variable-height rows.

So everything the table already does is preserved: **column sizing/resizing, the sticky header, sorting, filtering, column show/hide & reorder, row selection, row clicks**, and the `data-name`/`className` conventions the theme relies on.

## API

```ts
type TableVirtualizationOptions = {
  estimateRowHeight?: number,   // default 48, refined by measurement
  overscan?: number,            // default 8
  scroll?: 'window' | 'container',
}
// TableDisplay
virtualized?: boolean | TableVirtualizationOptions   // default false
```

### Scroll modes
- **`window`** (default) — windows against the page/document scroll. Drops into page-scrolled / document-scroll infinite lists (with a sentinel below the table) with no layout change.
- **`container`** — windows against the table container's own scroll. The container (`data-name="table-container"`) needs a bounded height + `overflow-y: auto`.

### Filler rows
Filler rows (`isUsingFillerRows`) are **ignored while virtualized** — virtualization already reserves the full scroll height, so they're unnecessary and incompatible. Documented on the prop.

## Compatibility / safety
- `virtualized` defaults to `false`; **non-virtualized tables are completely unchanged.**
- SSR/first-paint is guarded with an `isMounted` gate (renders plain rows until mounted) to avoid a window-virtualizer hydration mismatch.

## Validation
- `npm run build` (tsup + dts) passes; `VirtualizedTableBody` and `virtualized` are in the published `.d.ts`.
- `eslint .` clean, `jest` green (82 tests).
- `@tanstack/react-virtual@3.14.3` added to `dependencies` (and `tsup` externals); version bumped to **0.11.0**; CHANGELOG updated.

## Downstream
Adopted in `helpwave/tasks` (Patient/Task table views) in a companion PR that bumps `@helpwave/hightide` to `^0.11.0` — that PR depends on this one being merged & published first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017NmNguzr2xC7nJrqQgU7du

---
_Generated by [Claude Code](https://claude.ai/code/session_017NmNguzr2xC7nJrqQgU7du)_