### PR TITLE
style(table): drop explanatory comments from the virtualization code

### DIFF
--- a/src/components/layout/table/TableDisplay.tsx
+++ b/src/components/layout/table/TableDisplay.tsx
@@ -10,15 +10,6 @@ import { VirtualizedTableBody } from './VirtualizedTableBody'
 export interface TableDisplayProps extends TableHTMLAttributes<HTMLTableElement> {
   containerProps?: Omit<React.HTMLAttributes<HTMLDivElement>, 'children'>,
   tableHeaderProps?: Omit<TableHeaderProps, 'children' | 'table'>,
-  /**
-   * Opt into row virtualization (windowing): only the rows in (or near) the viewport are mounted to
-   * the DOM, so very large lists stay responsive. Pass `true` for the defaults or an options object
-   * to tune it (see {@link TableVirtualizationOptions}). Defaults to window-scroll, which drops into
-   * page-scrolled / infinite-scroll layouts without any change.
-   *
-   * Filler rows are ignored while virtualized (the reserved scroll height already fills the table),
-   * so `isUsingFillerRows` has no effect in this mode. Defaults to `false` (unchanged behaviour).
-   */
   virtualized?: boolean | TableVirtualizationOptions,
 }
 

--- a/src/components/layout/table/VirtualizedTableBody.tsx
+++ b/src/components/layout/table/VirtualizedTableBody.tsx
@@ -9,32 +9,13 @@ import { PropsUtil } from '@/src/utils/propsUtil'
 import { BagFunctionUtil } from '@/src/utils/bagFunctions'
 
 export type TableVirtualizationOptions = {
-  /** Estimated row height in px, refined by measurement once rows mount. Default `48`. */
   estimateRowHeight?: number,
-  /** Rows rendered above and below the viewport to avoid blank space while scrolling. Default `8`. */
   overscan?: number,
-  /**
-   * Which scroll context to track:
-   * - `'window'` (default) windows against the page/document scroll. Use this when the list
-   *   scrolls with the page (e.g. a document-scroll infinite list with a sentinel below the table).
-   * - `'container'` windows against the table container's own scroll. The container
-   *   (`data-name="table-container"`) needs a bounded height and `overflow-y: auto` for this.
-   */
   scroll?: 'window' | 'container',
 }
 
 export type VirtualizedTableBodyProps = TableVirtualizationOptions
 
-/**
- * Drop-in replacement for {@link TableBody} that only mounts the visible rows (plus a small
- * overscan) instead of the whole row model. Rows stay in normal table flow — a single spacer
- * `<tr>` above and below the window reserves the scroll height — so column sizing (driven by the
- * `<colgroup>`), the sticky header, resizing, sorting/filtering, selection and row clicks all keep
- * working unchanged. Per-row heights are measured, so variable-height rows are supported.
- *
- * Filler rows are intentionally ignored here: virtualization already reserves the full scroll
- * height, so `isUsingFillerRows` is a no-op while virtualized.
- */
 export const VirtualizedTableBody = ({
   estimateRowHeight = 48,
   overscan = 8,
@@ -50,10 +31,6 @@ export const VirtualizedTableBody = ({
 
   useEffect(() => setIsMounted(true), [])
 
-  // In window mode the virtualizer needs the body's offset from the top of the document so it can
-  // map window scroll -> row positions. That offset only moves when layout above the table changes
-  // (resize), not when rows are appended below, so we track it via a ResizeObserver/resize listener
-  // and keep the dependency list narrow rather than recomputing on every row-count change.
   useEffect(() => {
     if (scroll !== 'window') return
     const element = bodyRef.current
@@ -78,7 +55,6 @@ export const VirtualizedTableBody = ({
     overscan,
     getItemKey: (index: number) => rows[index]?.id ?? index,
   }
-  // Hooks must run unconditionally; we just pick which result to use based on `scroll`.
   const windowVirtualizer = useWindowVirtualizer({ ...common, scrollMargin })
   const containerVirtualizer = useVirtualizer({ ...common, getScrollElement: () => containerRef.current })
   const virtualizer = scroll === 'window' ? windowVirtualizer : containerVirtualizer
@@ -102,9 +78,6 @@ export const VirtualizedTableBody = ({
     </tr>
   )
 
-  // Before mount, render the rows in plain flow (no windowing). The window virtualizer produces an
-  // empty range until it has measured the scroll position, so gating here avoids an SSR/hydration
-  // mismatch. Consumers that fetch rows client-side render nothing here anyway.
   if (!isMounted) {
     return (
       <tbody ref={bodyRef}>

--- a/stories/Layout/Table/VirtualizedInfiniteScrolling.stories.tsx
+++ b/stories/Layout/Table/VirtualizedInfiniteScrolling.stories.tsx
@@ -9,17 +9,6 @@ import { TableColumnSwitcher } from '@/src/components/layout/table/TableColumnSw
 import { Chip } from '@/src/components/display-and-visualization/Chip'
 import { useHightideTranslation } from '@/src/i18n/useHightideTranslation'
 
-/*
- * Mirrors the TanStack "virtualized infinite scrolling" example
- * (https://tanstack.com/table/v8/docs/framework/react/examples/virtualized-infinite-scrolling)
- * against hightide's table: a large, paginated-on-scroll list where only the visible rows are
- * mounted to the DOM via the `virtualized` prop. Rendered in `container` scroll mode (a bounded,
- * internally-scrolling table with a sticky header), so the whole demo is self-contained.
- *
- * Open the elements panel while scrolling: the `<tbody>` only ever holds the visible rows plus a
- * small overscan, regardless of how many rows have been fetched.
- */
-
 type Person = {
   id: string,
   name: string,
@@ -33,11 +22,11 @@ type Person = {
 
 const statuses = ['active', 'inactive', 'pending'] as const
 
-// Deterministic data so the story looks the same on every load.
 faker.seed(20260624)
 
 const TOTAL_ROWS = 5000
 const FETCH_SIZE = 50
+const BOTTOM_THRESHOLD_PX = 500
 
 const allRows: Person[] = range(TOTAL_ROWS).map((index) => ({
   id: String(index + 1),
@@ -50,15 +39,11 @@ const allRows: Person[] = range(TOTAL_ROWS).map((index) => ({
   joined: faker.date.past({ years: 10 }),
 }))
 
-// Pretend backend: returns one page after a short delay.
 const fetchPage = async (pageIndex: number): Promise<Person[]> => {
   await new Promise((resolve) => setTimeout(resolve, 600))
   const start = pageIndex * FETCH_SIZE
   return allRows.slice(start, start + FETCH_SIZE)
 }
-
-// 500px from the bottom we kick off the next page.
-const BOTTOM_THRESHOLD_PX = 500
 
 const meta: Meta = {}
 
@@ -90,7 +75,6 @@ export const virtualizedInfiniteScrolling: Story = {
       setIsFetching(false)
     }, [])
 
-    // Load the first page on mount; the rest stream in as the user scrolls.
     useEffect(() => {
       void fetchNextPage()
     }, [fetchNextPage])
@@ -107,8 +91,6 @@ export const virtualizedInfiniteScrolling: Story = {
       <Table
         table={{
           data: flatData,
-          // Virtualization reserves the full scroll height itself, so filler rows are unnecessary,
-          // and we put every fetched row into a single page so they are all available to window.
           isUsingFillerRows: false,
           initialState: { pagination: { pageIndex: 0, pageSize: TOTAL_ROWS } },
         }}


### PR DESCRIPTION
Follow-up to #238. Removes the explanatory comments / JSDoc from the table virtualization code — no behavioural change, just leaving the code to read on its own.

- `VirtualizedTableBody.tsx` — inline + block comments removed.
- `TableDisplay.tsx` — JSDoc on the `virtualized` prop removed.
- `VirtualizedInfiniteScrolling.stories.tsx` — comment block + inline notes removed.

Net: 55 comment-line deletions, no logic touched. `eslint` clean; the three files typecheck clean (`tsc` shows only the pre-existing errors in unrelated stories).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017NmNguzr2xC7nJrqQgU7du

---
_Generated by [Claude Code](https://claude.ai/code/session_017NmNguzr2xC7nJrqQgU7du)_