### PR TITLE
fix(table,focus): opaque sticky header and guard focus-trap unmount (…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.12.0] - 2026-06-24
+
+### Fixed
+- The sticky table header (`tableHeaderProps.isSticky`) now stays opaque while the body scrolls. It already had a solid background but no stacking order, so the later-in-DOM body rows painted over it and it looked transparent; it now sits above them via `z-index`.
+- `useFocusTrap` no longer throws `Cannot read properties of null (reading 'contains')` when a trapped element unmounts. Unpausing an outer trap whose container had already been removed (e.g. closing a stacked popup or in-table editor) is now guarded against a null container ref.
+
 ## [0.11.0] - 2026-06-24
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "access": "public"
   },
   "license": "MPL-2.0",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "files": [
     "dist"
   ],

--- a/src/hooks/focus/useFocusTrap.ts
+++ b/src/hooks/focus/useFocusTrap.ts
@@ -187,7 +187,9 @@ export const useFocusTrap = ({
 
       function unpause() {
         setPaused(false)
-        if (!container.current.contains(document.activeElement as HTMLElement)) {
+        // The container may already be unmounted when an outer trap is unpaused
+        // (e.g. closing a stacked popup), so guard against a null ref.
+        if (container.current && !container.current.contains(document.activeElement as HTMLElement)) {
           focusElement()
         }
       }

--- a/src/style/theme/components/table.css
+++ b/src/style/theme/components/table.css
@@ -24,7 +24,7 @@
     @apply bg-table-header-background text-description font-bold;
 
     &[data-sticky] {
-      @apply sticky top-0;
+      @apply sticky top-0 z-10;
     }
   }
 


### PR DESCRIPTION
…0.12.0)

- table: the sticky header had a solid background but no stacking order, so the later-in-DOM body rows painted over it and it appeared transparent while scrolling a virtualized list. Give the sticky header cell a z-index so it stays above the body.

- useFocusTrap: unpausing an outer trap whose container had already been unmounted (e.g. closing a stacked popup or in-table editor) dereferenced a null container ref and threw "Cannot read properties of null (reading 'contains')". Guard against the null container.

Bump to 0.12.0 and document both fixes in the changelog.