### PR TITLE
fix: center dialogs and anchored pop-ups without a positioning transform (Safari)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.12.10] - 2026-06-30
+
+### Fixed
+
+- `Dialog` and anchored pop-ups (e.g. `PopUp`, date field and selection dialogs) rendering off-center on Safari/WebKit; centering and anchored positioning no longer rely on a static `translate`/`transform` that the `pop-in` `scale` animation dropped. `Dialog` now centers via `inset` + auto margins and `useAnchoredPosition` positions via absolute pixel coordinates.
+
 ## [0.12.9] - 2026-06-30
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "access": "public"
   },
   "license": "MPL-2.0",
-  "version": "0.12.9",
+  "version": "0.12.10",
   "files": [
     "dist"
   ],

--- a/src/hooks/useAnchoredPosition.ts
+++ b/src/hooks/useAnchoredPosition.ts
@@ -196,15 +196,19 @@ function calculatePosition({
     }
   }
 
-  const adjustedTranslateX = (bestPosition.clampedLeft - bestPosition.left) / bestPosition.width * 100
-  const adjustedTranslateY = (bestPosition.clampedTop - bestPosition.top) / bestPosition.height * 100
-
+  // Position the floating element with absolute pixel coordinates instead of a
+  // translate transform. `clampedLeft`/`clampedTop` already encode the final
+  // on-screen position (anchor base + alignment offset + screen-edge clamping),
+  // so this is visually identical to the previous transform-based positioning.
+  // We avoid `transform: translate()` because the pop-in animation animates the
+  // `scale` transform; on Safari/WebKit a static positioning transform combined
+  // with an animated one gets dropped, mis-placing the popup. `transformOrigin`
+  // is kept so the scale animation still grows from the popup's top-left corner.
   return {
-    left: bestPosition.left,
-    top: bestPosition.top,
+    left: bestPosition.clampedLeft,
+    top: bestPosition.clampedTop,
     maxWidth: bestPosition.maxWidth,
     maxHeight: bestPosition.maxHeight,
-    transform: `translate(${adjustedTranslateX}%, ${adjustedTranslateY}%)`,
     transformOrigin: 'top left',
   }
 }

--- a/src/style/theme/components/dialog.css
+++ b/src/style/theme/components/dialog.css
@@ -43,11 +43,19 @@
       animation-name: pop-in;
     }
 
+    /*
+     * Center via inset + auto margins instead of a translate transform.
+     * The pop-in animation above animates the `scale` transform property. On
+     * Safari/WebKit, combining an animated `scale` with a static positioning
+     * translate (the usual top/left 50% + -translate-1/2 trick) drops the
+     * translate and renders the dialog off-center. Auto-margin centering needs
+     * no positioning transform, so it stays correct while `scale` animates.
+     */
     &[data-position="top"] {
-      @apply fixed top-8 left-1/2 -translate-x-1/2;
+      @apply fixed inset-x-0 top-8 mx-auto w-fit;
     }
     &[data-position="center"] {
-      @apply fixed left-1/2 -translate-x-1/2 top-1/2 -translate-y-1/2;
+      @apply fixed inset-0 m-auto w-fit h-fit;
     }
   }
 }


### PR DESCRIPTION
## Problem

On Safari/WebKit, `Dialog`s and anchored pop-ups render **off-center**. This was being worked around per-component downstream in `tasks` (e.g. [`7a133fa`](https://github.com/helpwave/tasks/commit/7a133fa0701424fb7bd1b45591683fb4ca341830) added `!inset-0 !m-auto !translate-none` to `LocationSelectionDialog`). This PR fixes the **root cause** in hightide so every dialog/pop-up is fixed at once.

### Root cause

The `pop-in` animation animates the **`scale`** transform property. Two positioning mechanisms placed elements using a **static `translate`/`transform` on the same element**:

- **`Dialog`** (`dialog.css`): centered with `left-1/2 -translate-x-1/2 top-1/2 -translate-y-1/2`
- **Anchored pop-ups** (`useAnchoredPosition` → `PopUp`, date-field pop-ups, selection dialogs, …): positioned with `transform: translate(x%, y%)`

On Safari/WebKit, combining an **animated** `scale` with a **static** positioning translate causes the translate to be dropped, so the element snaps to its untranslated coordinates and renders off-center.

## Fix

Remove the positioning transform from both mechanisms so nothing competes with the `scale` animation. The rendered position is **identical** — only the mechanism changes.

- **`src/style/theme/components/dialog.css`** — center via `inset` + auto margins (`fixed inset-0 m-auto w-fit h-fit`; `inset-x-0 top-8 mx-auto w-fit` for `top`).
- **`src/hooks/useAnchoredPosition.ts`** — position via the already-computed clamped pixel `left`/`top` instead of a translate transform (`clampedLeft = left + width·translateX%`, so it's mathematically equivalent). `transformOrigin: 'top left'` is kept so the scale still grows from the top-left corner.

This covers all dialogs (selection, confirm, date-time) and all anchored pop-ups (`PopUp`, `Tooltip`, `Navigation`) in one place.

## Verification

- `tsc --noEmit`: no errors in the changed files (pre-existing story/i18n errors unrelated)
- `eslint`: clean
- `jest`: **98/98 pass**
- `build-css`: compiles to `inset: 0; margin: auto; width/height: fit-content` as intended

## Notes

- Bumped to `0.12.10` with a CHANGELOG `Fixed` entry.
- The `!inset-0 !m-auto !translate-none` workaround in `tasks` is intentionally left in place — it's still needed until `tasks` bumps its hightide dependency to a release containing this fix, after which those per-component overrides can be removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)