### PR TITLE
fix: externalize next so navigation actually routes client-side (0.12.11)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.12.11] - 2026-07-01
+
+### Fixed
+
+- `next` (and its subpaths) are now marked external in the build instead of being bundled. Previously `next/link`, `next/image` and Next's router context were embedded in the bundle, so `Link`/`useRouter` read an empty router context in consumer apps and the `0.12.10` navigation change still fell back to full-page navigation. All navigation components (`AppPage` sidebar, `Navigation`, `BreadCrumbs`) now use the host app's Next runtime and route client-side; the bundle also shrinks ~250KB
+
+### Changed
+
+- `next` declared as an optional peer dependency (`>=15`)
+
 ## [0.12.10] - 2026-06-30
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.12.10] - 2026-06-30
+
+### Fixed
+
+- Vertical navigation tree items (`AppPage` sidebar) now navigate client-side via `next/link` instead of `window.location.assign`, avoiding a full page reload on every navigation and fixing pages occasionally rendering incorrectly after using the browser's back button
+- `Dialog` and anchored pop-ups (e.g. `PopUp`, date field and selection dialogs) rendering off-center on Safari/WebKit; centering and anchored positioning no longer rely on a static `translate`/`transform` that the `pop-in` `scale` animation dropped. `Dialog` now centers via `inset` + auto margins and `useAnchoredPosition` positions via absolute pixel coordinates.
+
 ## [0.12.9] - 2026-06-30
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@helpwave/hightide",
-  "version": "0.12.8",
+  "version": "0.12.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@helpwave/hightide",
-      "version": "0.12.8",
+      "version": "0.12.10",
       "license": "MPL-2.0",
       "dependencies": {
         "@helpwave/internationalization": "0.4.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@helpwave/hightide",
-  "version": "0.12.10",
+  "version": "0.12.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@helpwave/hightide",
-      "version": "0.12.10",
+      "version": "0.12.11",
       "license": "MPL-2.0",
       "dependencies": {
         "@helpwave/internationalization": "0.4.0",
@@ -54,8 +54,14 @@
         "vite": "7.3.5"
       },
       "peerDependencies": {
+        "next": ">=15",
         "react": "^19.0.0",
         "react-dom": "^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "next": {
+          "optional": true
+        }
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -2905,7 +2911,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
       "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "peer": true,
@@ -2920,7 +2925,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2944,7 +2948,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2968,7 +2971,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2986,7 +2988,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3004,7 +3005,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3022,7 +3022,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3040,7 +3039,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3058,7 +3056,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3076,7 +3073,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3094,7 +3090,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3112,7 +3107,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3130,7 +3124,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3148,7 +3141,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3172,7 +3164,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3196,7 +3187,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3220,7 +3210,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3244,7 +3233,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3268,7 +3256,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3292,7 +3279,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3316,7 +3302,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3340,7 +3325,6 @@
       "cpu": [
         "wasm32"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
       "optional": true,
       "peer": true,
@@ -3361,7 +3345,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3382,7 +3365,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3403,7 +3385,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -4757,7 +4738,7 @@
       "version": "16.2.9",
       "resolved": "https://registry.npmjs.org/@next/env/-/env-16.2.9.tgz",
       "integrity": "sha512-ki5VxxXfzD/9TDe13wyeTKIjQTAwBVpnr8KhRDUr8ltMUq1/NBpWNT5tiPoxiGl+PHM4X2ahSOiPk6iAimIzPg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "peer": true
     },
@@ -4778,7 +4759,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4796,7 +4776,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4814,7 +4793,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4832,7 +4810,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4850,7 +4827,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4868,7 +4844,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4886,7 +4861,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4904,7 +4878,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6642,7 +6615,7 @@
       "version": "0.5.15",
       "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
       "integrity": "sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
@@ -8583,7 +8556,7 @@
       "version": "2.10.37",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.37.tgz",
       "integrity": "sha512-girxaJ7WZssDOFhzCGZTDKoTa1gk6A1TbflaYTpykLJ4UU9Fz9kx1aREM8JCuoVHbL8X8T/mJg7w2oYSq72Oig==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.cjs"
@@ -8798,7 +8771,7 @@
       "version": "1.0.30001799",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001799.tgz",
       "integrity": "sha512-hG1bReV+OUU+MOqK4t/ZWI0tZOyz3rqS9XuhOUz1cIcbwBKjOyJEJuw9ER5JuNyqxNk8u/JUVbGibBOL1yrjFw==",
-      "dev": true,
+      "devOptional": true,
       "funding": [
         {
           "type": "opencollective",
@@ -8912,7 +8885,7 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
       "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/cliui": {
@@ -14101,7 +14074,7 @@
       "version": "3.3.12",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
       "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
-      "dev": true,
+      "devOptional": true,
       "funding": [
         {
           "type": "github",
@@ -14150,7 +14123,7 @@
       "version": "16.2.9",
       "resolved": "https://registry.npmjs.org/next/-/next-16.2.9.tgz",
       "integrity": "sha512-MEOJiq/UvuezAdqVSceHbqDgZt1kDw2tpGVOlsdIoJsQdbN2JY2hpVG4xnXGkbdJUOEWhnRfiu/O4Hpc9Juwww==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -14829,7 +14802,7 @@
       "version": "8.5.15",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
       "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
-      "dev": true,
+      "devOptional": true,
       "funding": [
         {
           "type": "opencollective",
@@ -15570,7 +15543,6 @@
       "version": "0.34.5",
       "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
       "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "optional": true,
@@ -15617,7 +15589,6 @@
       "version": "7.8.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
       "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
-      "dev": true,
       "license": "ISC",
       "optional": true,
       "peer": true,
@@ -16105,7 +16076,7 @@
       "version": "5.1.6",
       "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.1.6.tgz",
       "integrity": "sha512-qSVyDTeMotdvQYoHWLNGwRFJHC+i+ZvdBRYosOFgC+Wg1vx4frN2/RG/NA7SYqqvKNLf39P2LSRA2pu6n0XYZA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "client-only": "0.0.1"

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "access": "public"
   },
   "license": "MPL-2.0",
-  "version": "0.12.9",
+  "version": "0.12.10",
   "files": [
     "dist"
   ],

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "access": "public"
   },
   "license": "MPL-2.0",
-  "version": "0.12.10",
+  "version": "0.12.11",
   "files": [
     "dist"
   ],
@@ -51,8 +51,14 @@
     "tailwindcss": "4.1.18"
   },
   "peerDependencies": {
+    "next": ">=15",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
+  },
+  "peerDependenciesMeta": {
+    "next": {
+      "optional": true
+    }
   },
   "devDependencies": {
     "@babel/core": "7.29.7",

--- a/src/components/layout/navigation/navigation-menus/VerticalNavigationItem.tsx
+++ b/src/components/layout/navigation/navigation-menus/VerticalNavigationItem.tsx
@@ -1,5 +1,7 @@
-import type { KeyboardEvent } from 'react'
+import type { KeyboardEvent, MouseEvent } from 'react'
 import { useCallback, useRef } from 'react'
+import Link from 'next/link'
+import { useRouter } from 'next/navigation'
 import { ExternalLink } from 'lucide-react'
 import { ExpansionIcon } from '@/src/components/display-and-visualization/ExpansionIcon'
 import { useNavigationItem } from './NavigationContext'
@@ -22,6 +24,7 @@ export function VerticalNavigationItem({
   items,
   depth = 0,
 }: VerticalNavigationItemProps) {
+  const router = useRouter()
   const headerRef = useRef<HTMLDivElement>(null)
   const {
     expanded,
@@ -40,6 +43,23 @@ export function VerticalNavigationItem({
 
   const hasChildren = items != null && items.length > 0
   const firstChildId = hasChildren ? items[0]?.id : undefined
+
+  const navigateToUrl = useCallback(() => {
+    if (url == null) return
+    if (external) {
+      window.open(url, '_blank', 'noopener,noreferrer')
+      return
+    }
+    router.push(url)
+  }, [external, router, url])
+
+  const handleLinkClick = useCallback((event: MouseEvent<HTMLAnchorElement>) => {
+    event.stopPropagation()
+    if (external) return
+    if (event.metaKey || event.ctrlKey || event.shiftKey || event.button !== 0) return
+    event.preventDefault()
+    navigateToUrl()
+  }, [external, navigateToUrl])
 
   const handleKeyDown = useCallback((event: KeyboardEvent<HTMLLIElement>) => {
     if (!isFocused || event.target !== event.currentTarget) return
@@ -91,43 +111,42 @@ export function VerticalNavigationItem({
     if (event.key === 'Enter' || event.key === ' ') {
       if (hasChildren) {
         toggleExpansion(id, { isFocusing: true })
-      } else {
-        navigateTo(id)
-      }
-      if (url == null) return
-      if (external) {
-        window.open(url, '_blank', 'noopener,noreferrer')
         return
       }
-      window.location.assign(url)
+      navigateTo(id)
+      if (url == null) return
+      event.preventDefault()
+      navigateToUrl()
     }
-  }, [collapse, expand, expanded, external, first, firstChildId, hasChildren, id, isFocused, last, navigateTo, next, path, previous, toggleExpansion, url])
+  }, [collapse, expand, expanded, first, firstChildId, hasChildren, id, isFocused, last, navigateTo, navigateToUrl, next, path, previous, toggleExpansion, url])
 
   const handleHeaderActivate = useCallback(() => {
     toggleExpansion(id, { isFocusing: true })
   }, [id, toggleExpansion])
 
-  const handleLeafActivate = useCallback(() => {
+  const handleLeafActivate = useCallback((event: MouseEvent<HTMLLIElement>) => {
+    if ((event.target as Element).closest('[data-name="vertical-navigation-item-link"]')) return
     navigateTo(id)
-    if (url == null) return
-    if (external) {
-      window.open(url, '_blank', 'noopener,noreferrer')
-      return
-    }
-    window.location.assign(url)
-  }, [external, id, navigateTo, url])
+    navigateToUrl()
+  }, [id, navigateTo, navigateToUrl])
 
   const labelContent = url == null ? (
     label
-  ) : external ? (
-    <span data-name="vertical-navigation-item-link">
-      {label}
-      <ExternalLink className="vertical-navigation-item-link-external-icon" />
-    </span>
   ) : (
-    <span data-name="vertical-navigation-item-link">
+    <Link
+      href={url}
+      data-name="vertical-navigation-item-link"
+      tabIndex={-1}
+      draggable={false}
+      target={external ? '_blank' : undefined}
+      rel={external ? 'noopener noreferrer' : undefined}
+      onClick={handleLinkClick}
+    >
       {label}
-    </span>
+      {external && (
+        <ExternalLink className="vertical-navigation-item-link-external-icon" />
+      )}
+    </Link>
   )
 
   if (!hasChildren) {

--- a/src/hooks/useAnchoredPosition.ts
+++ b/src/hooks/useAnchoredPosition.ts
@@ -63,49 +63,49 @@ function calculatePosition({
     let translateYPercent: number
 
     switch (hAlign) {
-    case 'beforeStart':
-      left = anchorRect.left
-      translateXPercent = -100
-      break
-    case 'afterStart':
-      left = anchorRect.left
-      translateXPercent = 0
-      break
-    case 'center':
-      left = anchorCenterX
-      translateXPercent = -50
-      break
-    case 'beforeEnd':
-      left = anchorRect.right
-      translateXPercent = -100
-      break
-    case 'afterEnd':
-      left = anchorRect.right
-      translateXPercent = 0
-      break
+      case 'beforeStart':
+        left = anchorRect.left
+        translateXPercent = -100
+        break
+      case 'afterStart':
+        left = anchorRect.left
+        translateXPercent = 0
+        break
+      case 'center':
+        left = anchorCenterX
+        translateXPercent = -50
+        break
+      case 'beforeEnd':
+        left = anchorRect.right
+        translateXPercent = -100
+        break
+      case 'afterEnd':
+        left = anchorRect.right
+        translateXPercent = 0
+        break
     }
 
     switch (vAlign) {
-    case 'beforeStart':
-      top = anchorRect.top
-      translateYPercent = -100
-      break
-    case 'afterStart':
-      top = anchorRect.top
-      translateYPercent = 0
-      break
-    case 'center':
-      top = anchorCenterY
-      translateYPercent = -50
-      break
-    case 'beforeEnd':
-      top = anchorRect.bottom
-      translateYPercent = -100
-      break
-    case 'afterEnd':
-      top = anchorRect.bottom
-      translateYPercent = 0
-      break
+      case 'beforeStart':
+        top = anchorRect.top
+        translateYPercent = -100
+        break
+      case 'afterStart':
+        top = anchorRect.top
+        translateYPercent = 0
+        break
+      case 'center':
+        top = anchorCenterY
+        translateYPercent = -50
+        break
+      case 'beforeEnd':
+        top = anchorRect.bottom
+        translateYPercent = -100
+        break
+      case 'afterEnd':
+        top = anchorRect.bottom
+        translateYPercent = 0
+        break
     }
 
     if (gap !== 0) {
@@ -196,15 +196,11 @@ function calculatePosition({
     }
   }
 
-  const adjustedTranslateX = (bestPosition.clampedLeft - bestPosition.left) / bestPosition.width * 100
-  const adjustedTranslateY = (bestPosition.clampedTop - bestPosition.top) / bestPosition.height * 100
-
   return {
-    left: bestPosition.left,
-    top: bestPosition.top,
+    left: bestPosition.clampedLeft,
+    top: bestPosition.clampedTop,
     maxWidth: bestPosition.maxWidth,
     maxHeight: bestPosition.maxHeight,
-    transform: `translate(${adjustedTranslateX}%, ${adjustedTranslateY}%)`,
     transformOrigin: 'top left',
   }
 }
@@ -228,10 +224,10 @@ const measureSizes = ({
   anchorRef,
   windowRef,
 }: {
-    containerRef?: RefObject<HTMLElement | null>,
-    anchorRef?: RefObject<HTMLElement | null>,
-    windowRef?: RefObject<HTMLElement | null>,
-  }) => {
+  containerRef?: RefObject<HTMLElement | null>,
+  anchorRef?: RefObject<HTMLElement | null>,
+  windowRef?: RefObject<HTMLElement | null>,
+}) => {
   return {
     container: containerRef?.current?.getBoundingClientRect(),
     anchor: anchorRef?.current?.getBoundingClientRect(),
@@ -306,18 +302,18 @@ export function useAnchoredPosition({
   const calculate = useCallback(() => {
     const newMeasurement = measureSizes({ containerRef, anchorRef, windowRef })
     if (!newMeasurement) return
-    if(isSameMeasurment(lastSizes.current, newMeasurement) && isSameOptions(options, lastOptions.current)) return
+    if (isSameMeasurment(lastSizes.current, newMeasurement) && isSameOptions(options, lastOptions.current)) return
     lastSizes.current = newMeasurement
     lastOptions.current = options
 
-    if(!newMeasurement.container) {
+    if (!newMeasurement.container) {
       return
     }
     const containerRect: RectangleBounds = newMeasurement.container
     const windowRect: RectangleBounds = newMeasurement.window
     const anchorRect: RectangleBounds = newMeasurement.anchor ?? newMeasurement.window
 
-    if(containerRect.width === 0 || containerRect.height === 0) {
+    if (containerRect.width === 0 || containerRect.height === 0) {
       return
     }
 
@@ -349,7 +345,7 @@ export function useAnchoredPosition({
   useScrollObserver({ observedElementRef: anchorRef, onScroll: calculate, isActive: isReactingToScroll && active })
 
   useEffect(() => {
-    if(!containerRef.current || !active) {
+    if (!containerRef.current || !active) {
       return
     }
     let timeout: NodeJS.Timeout

--- a/src/style/theme/components/dialog.css
+++ b/src/style/theme/components/dialog.css
@@ -42,12 +42,11 @@
     &[data-state="closing"] {
       animation-name: pop-in;
     }
-
     &[data-position="top"] {
-      @apply fixed top-8 left-1/2 -translate-x-1/2;
+      @apply fixed inset-x-0 top-8 mx-auto w-fit;
     }
     &[data-position="center"] {
-      @apply fixed left-1/2 -translate-x-1/2 top-1/2 -translate-y-1/2;
+      @apply fixed inset-0 m-auto w-fit h-fit;
     }
   }
 }

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -13,6 +13,11 @@ export default defineConfig({
   external: [
     'react',
     'react-dom',
+    // Keep next as a runtime dependency of the consumer app. Bundling it would embed a second
+    // copy of next/link, next/image and Next's router context, so those components would read an
+    // empty router context and fall back to full-page navigation instead of client-side routing.
+    'next',
+    /^next\//,
     'clsx',
     '@tanstack/react-table',
     '@tanstack/react-virtual',


### PR DESCRIPTION
## Problem

`0.12.10` (already on `main`, commit bcba913) switched `VerticalNavigationItem` to `next/link` + `useRouter` to stop the sidebar's full-page reloads. But that fix **does not work in consumer apps**, because the build bundles `next` instead of externalizing it.

`tsup.config.ts` had no `next` in its `external` list, so tsup embedded `next/link`, `next/image`, `next/navigation` **and a fresh copy of Next's router context** into `dist`. In a consumer app the bundled `Link`/`useRouter` read that embedded (empty) context instead of the host app's router — so navigation still falls back to a full-page reload. I confirmed this against the **published** `0.12.10` tarball: it embeds `node_modules/next/link.js` and has no external `next/*` imports.

This affects **every** navigation component — the `AppPage` sidebar, `Navigation`, and `BreadCrumbs`.

## Fix

- Mark `next` and its subpaths external in `tsup.config.ts` so the host app's Next runtime (and its router context) is used.
- Declare `next` as an **optional** peer dependency (`>=15`).
- Released as **`0.12.11`** (builds on the `0.12.10` `next/link` change already on `main`) + CHANGELOG.

## Verification

- `npm run build` succeeds; built **and packed** dist confirmed: `next/link`, `next/image`, `next/navigation` are now external imports, **zero** bundled copies of Next, and the re-created router context is gone. Bundle shrinks ~250KB.
- Consumer active-route highlighting keeps working because consumers (e.g. `tasks`) derive the active route from `usePathname()` (`next/navigation`), which updates reactively on client-side navigation — and `next/navigation` now resolves to the app's copy.

## Follow-up

`0.12.10` is published but still bundles Next, so consumers must go to **`0.12.11`** for a working fix. After `0.12.11` is published: `tasks` → `npm install @helpwave/hightide@0.12.11`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)