### PR TITLE
feat: add page-scroll virtualization mode and shared VirtualizedCardGrid

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "access": "public"
   },
   "license": "MPL-2.0",
-  "version": "0.12.16",
+  "version": "0.13.0",
   "files": [
     "dist"
   ],

--- a/src/components/layout/table/VirtualizedTableBody.tsx
+++ b/src/components/layout/table/VirtualizedTableBody.tsx
@@ -1,19 +1,23 @@
 import type { Key } from 'react'
-import { useEffect, useRef, useState } from 'react'
+import { useRef } from 'react'
 import type { Row } from '@tanstack/react-table'
 import { flexRender } from '@tanstack/react-table'
-import { useVirtualizer, useWindowVirtualizer } from '@tanstack/react-virtual'
 import clsx from 'clsx'
 import { useTableContainerContext, useTableStateWithoutSizingContext } from './TableContext'
 import { PropsUtil } from '@/src/utils/propsUtil'
 import { BagFunctionUtil } from '@/src/utils/bagFunctions'
 import { range } from '@/src/utils/array'
 import { FillerCell } from './FillerCell'
+import { useVirtualizedRows } from '../virtualization/useVirtualizedRows'
+import type { VirtualizationScroll } from '../virtualization/virtualizationScroll'
 
 export type TableVirtualizationOptions = {
   estimateRowHeight?: number,
   overscan?: number,
-  scroll?: 'window' | 'container',
+  scroll?: VirtualizationScroll,
+  /** Called for infinite scroll while nearing the bottom of the scroll region. */
+  onReachBottom?: () => void,
+  reachBottomThresholdPx?: number,
 }
 
 export type VirtualizedTableBodyProps = TableVirtualizationOptions
@@ -22,45 +26,26 @@ export const VirtualizedTableBody = ({
   estimateRowHeight = 48,
   overscan = 8,
   scroll = 'window',
+  onReachBottom,
+  reachBottomThresholdPx,
 }: VirtualizedTableBodyProps) => {
   const { table, onRowClick, isUsingFillerRows, fillerRowCell } = useTableStateWithoutSizingContext<unknown>()
   const { containerRef } = useTableContainerContext<unknown>()
   const rows = table.getRowModel().rows
 
   const bodyRef = useRef<HTMLTableSectionElement | null>(null)
-  const [isMounted, setIsMounted] = useState(false)
-  const [scrollMargin, setScrollMargin] = useState(0)
 
-  useEffect(() => setIsMounted(true), [])
-
-  useEffect(() => {
-    if (scroll !== 'window') return
-    const element = bodyRef.current
-    if (!element || typeof window === 'undefined') return
-    const measure = () => {
-      const next = element.getBoundingClientRect().top + window.scrollY
-      setScrollMargin(prev => (Math.abs(prev - next) < 1 ? prev : next))
-    }
-    measure()
-    const resizeObserver = new ResizeObserver(measure)
-    resizeObserver.observe(element)
-    window.addEventListener('resize', measure)
-    return () => {
-      resizeObserver.disconnect()
-      window.removeEventListener('resize', measure)
-    }
-  }, [scroll])
-
-  const common = {
+  const { virtualizer, offset, isMounted } = useVirtualizedRows({
+    scroll,
     count: rows.length,
-    estimateSize: () => estimateRowHeight,
+    estimateRowHeight,
     overscan,
     getItemKey: (index: number) => rows[index]?.id ?? index,
-  }
-  const windowVirtualizer = useWindowVirtualizer({ ...common, scrollMargin })
-  const containerVirtualizer = useVirtualizer({ ...common, getScrollElement: () => containerRef.current })
-  const virtualizer = scroll === 'window' ? windowVirtualizer : containerVirtualizer
-  const offset = scroll === 'window' ? scrollMargin : 0
+    contentRef: bodyRef,
+    containerRef,
+    onReachBottom,
+    reachBottomThresholdPx,
+  })
 
   const renderRow = (row: Row<unknown>, key: Key, measured: boolean, dataIndex?: number) => (
     <tr

--- a/src/components/layout/virtualization/VirtualizedCardGrid.tsx
+++ b/src/components/layout/virtualization/VirtualizedCardGrid.tsx
@@ -1,0 +1,143 @@
+import type { ReactNode } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
+import clsx from 'clsx'
+import { columnsForWidth, chunkIntoRows, overscanRowsForBuffer } from './gridLayout'
+import { useVirtualizedRows } from './useVirtualizedRows'
+import type { VirtualizationScroll } from './virtualizationScroll'
+
+const DEFAULT_GAP_PX = 12
+const DEFAULT_ESTIMATE_ROW_HEIGHT_PX = 220
+// Render roughly a screenful of extra rows in each direction so a fast mobile
+// momentum scroll cannot outrun the render and reveal a blank list.
+const DEFAULT_OVERSCAN_ROWS = overscanRowsForBuffer(800, DEFAULT_ESTIMATE_ROW_HEIGHT_PX)
+const DEFAULT_VIRTUALIZE_THRESHOLD = 40
+const DEFAULT_REACH_BOTTOM_THRESHOLD_PX = 600
+
+export type VirtualizedCardGridProps<T> = {
+  items: readonly T[],
+  getItemKey: (item: T) => string,
+  renderItem: (item: T) => ReactNode,
+  /** Minimum width a card may shrink to before the column count drops. */
+  minCardWidthPx: number,
+  gapPx?: number,
+  estimateRowHeightPx?: number,
+  overscanRows?: number,
+  /** Below this item count the grid renders every card without virtualization. */
+  virtualizeThreshold?: number,
+  /** Where the grid scrolls. Defaults to `'container'` (its own capped box). */
+  scroll?: VirtualizationScroll,
+  containerClassName?: string,
+  /** Called for infinite scroll while nearing the bottom of the scroll region. */
+  onReachBottom?: () => void,
+  reachBottomThresholdPx?: number,
+}
+
+/**
+ * A responsive, virtualized grid of cards backed by TanStack Virtual. Shares its
+ * scroll handling ({@link VirtualizationScroll} modes + infinite scroll) with
+ * the virtualized table via {@link useVirtualizedRows}, so a card grid and a
+ * table can behave identically inside the same scroll region.
+ */
+export function VirtualizedCardGrid<T>({
+  items,
+  getItemKey,
+  renderItem,
+  minCardWidthPx,
+  gapPx = DEFAULT_GAP_PX,
+  estimateRowHeightPx = DEFAULT_ESTIMATE_ROW_HEIGHT_PX,
+  overscanRows = DEFAULT_OVERSCAN_ROWS,
+  virtualizeThreshold = DEFAULT_VIRTUALIZE_THRESHOLD,
+  scroll = 'container',
+  containerClassName,
+  onReachBottom,
+  reachBottomThresholdPx = DEFAULT_REACH_BOTTOM_THRESHOLD_PX,
+}: VirtualizedCardGridProps<T>) {
+  const containerRef = useRef<HTMLDivElement | null>(null)
+  const [columns, setColumns] = useState(1)
+
+  useEffect(() => {
+    const element = containerRef.current
+    if (!element || typeof window === 'undefined') return
+
+    const measure = () => {
+      const nextColumns = columnsForWidth(element.clientWidth, minCardWidthPx, gapPx)
+      setColumns((prev) => (prev === nextColumns ? prev : nextColumns))
+    }
+
+    measure()
+    const resizeObserver = new ResizeObserver(measure)
+    resizeObserver.observe(element)
+    window.addEventListener('resize', measure)
+    return () => {
+      resizeObserver.disconnect()
+      window.removeEventListener('resize', measure)
+    }
+  }, [minCardWidthPx, gapPx])
+
+  const rows = useMemo(() => chunkIntoRows(items, columns), [items, columns])
+
+  const { virtualizer, offset, isMounted } = useVirtualizedRows({
+    scroll,
+    count: rows.length,
+    estimateRowHeight: estimateRowHeightPx,
+    overscan: overscanRows,
+    getItemKey: (index) => {
+      const first = rows[index]?.[0]
+      return first ? getItemKey(first) : index
+    },
+    contentRef: containerRef,
+    containerRef,
+    onReachBottom,
+    reachBottomThresholdPx,
+  })
+
+  useEffect(() => {
+    virtualizer.measure()
+  }, [columns, virtualizer])
+
+  const autoFillTemplate = `repeat(auto-fill, minmax(min(100%, ${minCardWidthPx}px), 1fr))`
+  const shouldVirtualize = isMounted && items.length > virtualizeThreshold
+
+  if (!shouldVirtualize) {
+    return (
+      <div ref={containerRef} className={clsx('w-full print:hidden', containerClassName)}>
+        <div className="grid w-full" style={{ gridTemplateColumns: autoFillTemplate, gap: gapPx }}>
+          {items.map(renderItem)}
+        </div>
+      </div>
+    )
+  }
+
+  const explicitTemplate = `repeat(${columns}, minmax(0, 1fr))`
+
+  return (
+    <div ref={containerRef} className={clsx('w-full print:hidden', containerClassName)}>
+      <div style={{ height: virtualizer.getTotalSize(), width: '100%', position: 'relative' }}>
+        {virtualizer.getVirtualItems().map((virtualRow) => {
+          const row = rows[virtualRow.index] ?? []
+          return (
+            <div
+              key={virtualRow.key}
+              data-index={virtualRow.index}
+              ref={virtualizer.measureElement}
+              style={{
+                position: 'absolute',
+                top: 0,
+                left: 0,
+                width: '100%',
+                transform: `translateY(${virtualRow.start - offset}px)`,
+              }}
+            >
+              <div
+                className="grid w-full"
+                style={{ gridTemplateColumns: explicitTemplate, gap: gapPx, paddingBottom: gapPx }}
+              >
+                {row.map(renderItem)}
+              </div>
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+}

--- a/src/components/layout/virtualization/gridLayout.ts
+++ b/src/components/layout/virtualization/gridLayout.ts
@@ -1,0 +1,30 @@
+/** Number of columns that fit into `containerWidth` given a minimum card width. */
+export function columnsForWidth(containerWidth: number, minCardWidthPx: number, gapPx: number): number {
+  if (!Number.isFinite(containerWidth) || containerWidth <= 0) return 1
+  if (!Number.isFinite(minCardWidthPx) || minCardWidthPx <= 0) return 1
+  const columns = Math.floor((containerWidth + gapPx) / (minCardWidthPx + gapPx))
+  return Math.max(1, columns)
+}
+
+/**
+ * Number of rows to render outside the visible window so that a fast (e.g. mobile
+ * momentum) scroll does not outrun React's render and reveal blank space. Derives
+ * the row count from a target pixel buffer and the (estimated) row height, never
+ * dropping below `minRows`.
+ */
+export function overscanRowsForBuffer(bufferPx: number, rowHeightPx: number, minRows = 6): number {
+  const floor = Math.max(1, Math.floor(minRows))
+  if (!Number.isFinite(bufferPx) || bufferPx <= 0) return floor
+  if (!Number.isFinite(rowHeightPx) || rowHeightPx <= 0) return floor
+  return Math.max(floor, Math.ceil(bufferPx / rowHeightPx))
+}
+
+/** Splits `items` into rows of at most `columns` entries each. */
+export function chunkIntoRows<T>(items: readonly T[], columns: number): T[][] {
+  const safeColumns = Math.max(1, Math.floor(columns) || 1)
+  const rows: T[][] = []
+  for (let i = 0; i < items.length; i += safeColumns) {
+    rows.push(items.slice(i, i + safeColumns))
+  }
+  return rows
+}

--- a/src/components/layout/virtualization/useVirtualizedRows.ts
+++ b/src/components/layout/virtualization/useVirtualizedRows.ts
@@ -1,0 +1,136 @@
+import type { Key, RefObject } from 'react'
+import { useEffect, useState } from 'react'
+import type { Virtualizer } from '@tanstack/react-virtual'
+import { useVirtualizer, useWindowVirtualizer } from '@tanstack/react-virtual'
+import {
+  findScrollableAncestor,
+  getScrollMetrics,
+  isNearBottom,
+  type VirtualizationScroll
+} from './virtualizationScroll'
+
+export type UseVirtualizedRowsOptions = {
+  scroll: VirtualizationScroll,
+  count: number,
+  estimateRowHeight: number,
+  overscan: number,
+  getItemKey?: (index: number) => Key,
+  /**
+   * The element whose top marks where the virtualized content starts (e.g. the
+   * `tbody` for a table, or the grid wrapper for a card grid). Used to measure
+   * the scroll offset for the `'window'` and `'page'` modes.
+   */
+  contentRef: RefObject<HTMLElement | null>,
+  /** The scroll container element for the `'container'` mode. */
+  containerRef?: RefObject<HTMLElement | null>,
+  /** Called while the user is within `reachBottomThresholdPx` of the bottom. */
+  onReachBottom?: () => void,
+  reachBottomThresholdPx?: number,
+}
+
+export type UseVirtualizedRowsResult = {
+  virtualizer: Virtualizer<Element, Element>,
+  /** Subtract from `virtualItem.start` to get a position relative to `contentRef`. */
+  offset: number,
+  /** The resolved scrollable ancestor for the `'page'` mode (else `null`). */
+  pageScrollElement: HTMLElement | null,
+  isMounted: boolean,
+}
+
+/**
+ * Shared virtualization plumbing for the table and card grid. Selects the right
+ * TanStack virtualizer for the requested {@link VirtualizationScroll} mode,
+ * measures the content offset for outer-scroll modes, resolves the page scroll
+ * container, and wires up "reached the bottom" callbacks for infinite scroll.
+ */
+export function useVirtualizedRows({
+  scroll,
+  count,
+  estimateRowHeight,
+  overscan,
+  getItemKey,
+  contentRef,
+  containerRef,
+  onReachBottom,
+  reachBottomThresholdPx = 600,
+}: UseVirtualizedRowsOptions): UseVirtualizedRowsResult {
+  const [scrollMargin, setScrollMargin] = useState(0)
+  const [pageScrollElement, setPageScrollElement] = useState<HTMLElement | null>(null)
+  const [isMounted, setIsMounted] = useState(false)
+
+  useEffect(() => setIsMounted(true), [])
+
+  const usesOuterScroll = scroll === 'window' || scroll === 'page'
+
+  // Resolve the page scroll container and measure where the content sits inside
+  // the outer scroll region. Both quantities are scroll-invariant, so re-running
+  // on layout changes (content growing, resize) is enough.
+  useEffect(() => {
+    if (!usesOuterScroll) return
+    const content = contentRef.current
+    if (!content || typeof window === 'undefined') return
+
+    const measure = () => {
+      if (scroll === 'page') {
+        const container = findScrollableAncestor(content)
+        setPageScrollElement(prev => (prev === container ? prev : container))
+        const top = container
+          ? content.getBoundingClientRect().top - container.getBoundingClientRect().top + container.scrollTop
+          : content.getBoundingClientRect().top + window.scrollY
+        setScrollMargin(prev => (Math.abs(prev - top) < 1 ? prev : top))
+        return
+      }
+      const top = content.getBoundingClientRect().top + window.scrollY
+      setScrollMargin(prev => (Math.abs(prev - top) < 1 ? prev : top))
+    }
+
+    measure()
+    const resizeObserver = new ResizeObserver(measure)
+    resizeObserver.observe(content)
+    window.addEventListener('resize', measure)
+    return () => {
+      resizeObserver.disconnect()
+      window.removeEventListener('resize', measure)
+    }
+  }, [scroll, usesOuterScroll, contentRef])
+
+  const common = {
+    count,
+    estimateSize: () => estimateRowHeight,
+    overscan,
+    ...(getItemKey ? { getItemKey } : {}),
+  }
+  const windowVirtualizer = useWindowVirtualizer({ ...common, scrollMargin })
+  const containerVirtualizer = useVirtualizer({ ...common, getScrollElement: () => containerRef?.current ?? null })
+  const pageVirtualizer = useVirtualizer({ ...common, getScrollElement: () => pageScrollElement, scrollMargin })
+
+  const virtualizer = (
+    scroll === 'window'
+      ? windowVirtualizer
+      : scroll === 'page'
+        ? pageVirtualizer
+        : containerVirtualizer
+  ) as unknown as Virtualizer<Element, Element>
+  const offset = usesOuterScroll ? scrollMargin : 0
+
+  // Infinite scroll: notify the consumer when the active scroll target nears its bottom.
+  useEffect(() => {
+    if (!onReachBottom || typeof window === 'undefined') return
+    const target: HTMLElement | Window | null =
+      scroll === 'window' ? window : scroll === 'page' ? pageScrollElement : containerRef?.current ?? null
+    if (!target) return
+
+    const handler = () => {
+      if (isNearBottom(getScrollMetrics(target), reachBottomThresholdPx)) onReachBottom()
+    }
+    target.addEventListener('scroll', handler, { passive: true } as AddEventListenerOptions)
+    window.addEventListener('resize', handler)
+    handler()
+    return () => {
+      target.removeEventListener('scroll', handler)
+      window.removeEventListener('resize', handler)
+    }
+  }, [scroll, pageScrollElement, containerRef, onReachBottom, reachBottomThresholdPx, isMounted])
+
+  return { virtualizer, offset, pageScrollElement, isMounted }
+}

--- a/src/components/layout/virtualization/virtualizationScroll.ts
+++ b/src/components/layout/virtualization/virtualizationScroll.ts
@@ -1,0 +1,55 @@
+/**
+ * Determines which element a virtualized list scrolls inside of.
+ *
+ * - `'container'`: the list scrolls inside its own capped box (the list owns a
+ *    `overflow-y-auto` element). Use when the list should keep a fixed height.
+ * - `'window'`: the list scrolls together with the document/`window`.
+ * - `'page'`: the list scrolls together with the nearest scrollable ancestor
+ *    (e.g. the `AppPage` content area). Use when the surrounding page should
+ *    expand and scroll as one, instead of the list scrolling inside a capped box.
+ */
+export type VirtualizationScroll = 'window' | 'container' | 'page'
+
+const SCROLLABLE_OVERFLOW = new Set(['auto', 'scroll', 'overlay'])
+
+/**
+ * Walks up the DOM from `element` and returns the nearest ancestor that is an
+ * actual vertical scroll container. Backs the `'page'` virtualization mode so a
+ * virtualized list can scroll together with the surrounding page instead of
+ * inside its own capped box.
+ */
+export function findScrollableAncestor(element: HTMLElement | null): HTMLElement | null {
+  if (!element || typeof window === 'undefined') return null
+  let node: HTMLElement | null = element.parentElement
+  while (node) {
+    const { overflowY } = window.getComputedStyle(node)
+    if (SCROLLABLE_OVERFLOW.has(overflowY) && node.scrollHeight > node.clientHeight) {
+      return node
+    }
+    node = node.parentElement
+  }
+  return null
+}
+
+export type ScrollMetrics = {
+  scrollTop: number,
+  scrollHeight: number,
+  clientHeight: number,
+}
+
+/** Reads scroll metrics uniformly from either an element or the `window`. */
+export function getScrollMetrics(target: HTMLElement | Window | null): ScrollMetrics {
+  if (!target || typeof window === 'undefined') {
+    return { scrollTop: 0, scrollHeight: 0, clientHeight: 0 }
+  }
+  if (target === window) {
+    const doc = document.scrollingElement ?? document.documentElement
+    return { scrollTop: window.scrollY, scrollHeight: doc.scrollHeight, clientHeight: window.innerHeight }
+  }
+  const element = target as HTMLElement
+  return { scrollTop: element.scrollTop, scrollHeight: element.scrollHeight, clientHeight: element.clientHeight }
+}
+
+export function isNearBottom(metrics: ScrollMetrics, thresholdPx: number): boolean {
+  return metrics.scrollHeight - metrics.scrollTop - metrics.clientHeight <= thresholdPx
+}

--- a/stories/Layout/Table/PageScrollTable.stories.tsx
+++ b/stories/Layout/Table/PageScrollTable.stories.tsx
@@ -1,0 +1,113 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { faker } from '@faker-js/faker'
+import { range } from '@/src/utils/array'
+import { Table } from '@/src/components/layout/table/Table'
+import { TableColumn } from '@/src/components/layout/table/TableColumn'
+import { Chip } from '@/src/components/display-and-visualization/Chip'
+
+type Person = {
+  id: string,
+  name: string,
+  city: string,
+  status: 'active' | 'inactive' | 'pending',
+  visits: number,
+}
+
+const statuses = ['active', 'inactive', 'pending'] as const
+
+faker.seed(20260703)
+
+const TOTAL_ROWS = 5000
+const FETCH_SIZE = 50
+
+const allRows: Person[] = range(TOTAL_ROWS).map((index) => ({
+  id: String(index + 1),
+  name: faker.person.fullName(),
+  city: faker.location.city(),
+  status: faker.helpers.arrayElement(statuses),
+  visits: faker.number.int({ min: 0, max: 1000 }),
+}))
+
+const fetchPage = async (pageIndex: number): Promise<Person[]> => {
+  await new Promise((resolve) => setTimeout(resolve, 600))
+  const start = pageIndex * FETCH_SIZE
+  return allRows.slice(start, start + FETCH_SIZE)
+}
+
+const meta: Meta = {}
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+/**
+ * The virtualized table with `scroll: 'page'` — it virtualizes against the
+ * nearest scrollable ancestor (here the bordered box, in a real app the
+ * `AppPage` content area) instead of its own capped box, and drives infinite
+ * scroll through the built-in `onReachBottom` option. This is the same shared
+ * scroll handling the `VirtualizedCardGrid` uses.
+ */
+export const pageScrollTable: Story = {
+  render: () => {
+    const [pages, setPages] = useState<Person[][]>([])
+    const [isFetching, setIsFetching] = useState(false)
+    const isFetchingRef = useRef(false)
+    const loadedPagesRef = useRef(0)
+
+    const flatData = useMemo(() => pages.flat(), [pages])
+
+    const fetchNextPage = useCallback(async () => {
+      if (isFetchingRef.current) return
+      if (loadedPagesRef.current * FETCH_SIZE >= TOTAL_ROWS) return
+      isFetchingRef.current = true
+      setIsFetching(true)
+      const rows = await fetchPage(loadedPagesRef.current)
+      setPages((prev) => [...prev, rows])
+      loadedPagesRef.current += 1
+      isFetchingRef.current = false
+      setIsFetching(false)
+    }, [])
+
+    useEffect(() => {
+      void fetchNextPage()
+    }, [fetchNextPage])
+
+    return (
+      <div className="max-h-128 overflow-y-auto rounded-lg border border-divider p-4 flex-col-4">
+        <p className="text-description typography-body-md">
+          This paragraph scrolls away with the table — the table rides the outer scroll container
+          and loads more rows as you approach the bottom.
+        </p>
+        <Table
+          table={{
+            data: flatData,
+            isUsingFillerRows: true,
+            initialState: { pagination: { pageIndex: 0, pageSize: TOTAL_ROWS } },
+          }}
+          paginationOptions={{ showPagination: false }}
+          displayProps={{
+            virtualized: { scroll: 'page', estimateRowHeight: 48, onReachBottom: fetchNextPage },
+          }}
+          footer={isFetching ? (
+            <span className="text-description typography-label-md">Fetching more…</span>
+          ) : null}
+        >
+          <TableColumn id="id" header="ID" accessorKey="id" sortingFn="alphanumeric" size={80} minSize={70} maxSize={120}/>
+          <TableColumn id="name" header="Name" accessorKey="name" sortingFn="text" size={220} minSize={160} maxSize={320} filterType="text"/>
+          <TableColumn id="city" header="City" accessorKey="city" sortingFn="text" size={200} minSize={140} maxSize={300} filterType="text"/>
+          <TableColumn
+            id="status"
+            header="Status"
+            accessorKey="status"
+            sortingFn="text"
+            size={150}
+            minSize={120}
+            maxSize={220}
+            cell={({ cell }) => (<Chip>{cell.getValue() as string}</Chip>)}
+          />
+          <TableColumn id="visits" header="Visits" accessorKey="visits" sortingFn="alphanumeric" size={120} minSize={100} maxSize={180} filterType="number"/>
+        </Table>
+      </div>
+    )
+  },
+}

--- a/stories/Layout/Virtualization/VirtualizedCardGrid.stories.tsx
+++ b/stories/Layout/Virtualization/VirtualizedCardGrid.stories.tsx
@@ -1,0 +1,162 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { faker } from '@faker-js/faker'
+import { range } from '@/src/utils/array'
+import { VirtualizedCardGrid } from '@/src/components/layout/virtualization/VirtualizedCardGrid'
+import { Chip } from '@/src/components/display-and-visualization/Chip'
+
+type Item = {
+  id: string,
+  name: string,
+  city: string,
+  status: 'active' | 'inactive' | 'pending',
+  visits: number,
+}
+
+const statuses = ['active', 'inactive', 'pending'] as const
+
+faker.seed(20260703)
+
+const TOTAL_ITEMS = 4000
+const FETCH_SIZE = 60
+
+const allItems: Item[] = range(TOTAL_ITEMS).map((index) => ({
+  id: String(index + 1),
+  name: faker.person.fullName(),
+  city: faker.location.city(),
+  status: faker.helpers.arrayElement(statuses),
+  visits: faker.number.int({ min: 0, max: 1000 }),
+}))
+
+const fetchPage = async (pageIndex: number): Promise<Item[]> => {
+  await new Promise((resolve) => setTimeout(resolve, 500))
+  const start = pageIndex * FETCH_SIZE
+  return allItems.slice(start, start + FETCH_SIZE)
+}
+
+const ItemCard = ({ item }: { item: Item }) => (
+  <div className="surface coloring-solid rounded-lg p-4 flex-col-2 h-full">
+    <div className="flex-row-2 items-center justify-between">
+      <span className="typography-title-sm truncate">{item.name}</span>
+      <Chip>{item.status}</Chip>
+    </div>
+    <span className="text-description typography-label-md">{item.city}</span>
+    <span className="text-description typography-label-sm">{`#${item.id} · ${item.visits} visits`}</span>
+  </div>
+)
+
+const useInfinitePages = () => {
+  const [pages, setPages] = useState<Item[][]>([])
+  const [isFetching, setIsFetching] = useState(false)
+  const isFetchingRef = useRef(false)
+  const loadedPagesRef = useRef(0)
+
+  const items = useMemo(() => pages.flat(), [pages])
+
+  const loadMore = useCallback(async () => {
+    if (isFetchingRef.current) return
+    if (loadedPagesRef.current * FETCH_SIZE >= TOTAL_ITEMS) return
+    isFetchingRef.current = true
+    setIsFetching(true)
+    const rows = await fetchPage(loadedPagesRef.current)
+    setPages((prev) => [...prev, rows])
+    loadedPagesRef.current += 1
+    isFetchingRef.current = false
+    setIsFetching(false)
+  }, [])
+
+  useEffect(() => {
+    void loadMore()
+  }, [loadMore])
+
+  return { items, isFetching, loadMore }
+}
+
+const meta: Meta<typeof VirtualizedCardGrid> = {
+  component: VirtualizedCardGrid,
+}
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+/**
+ * `scroll: 'container'` — the grid scrolls inside its own capped box. Best when
+ * the list should keep a fixed height regardless of how much data is loaded.
+ */
+export const containerScroll: Story = {
+  render: () => {
+    const { items, isFetching, loadMore } = useInfinitePages()
+    return (
+      <div className="flex-col-2">
+        <div className="flex-row-2 items-center justify-between">
+          <span className="typography-title-md">Container scroll</span>
+          <span className="text-description typography-label-md">{`${items.length} of ${TOTAL_ITEMS} loaded`}</span>
+        </div>
+        <VirtualizedCardGrid<Item>
+          items={items}
+          getItemKey={(item) => item.id}
+          minCardWidthPx={280}
+          scroll="container"
+          containerClassName="max-h-128 overflow-y-auto rounded-lg border border-divider p-2"
+          onReachBottom={loadMore}
+          renderItem={(item) => <ItemCard key={item.id} item={item} />}
+        />
+        {isFetching && (<span className="text-description typography-label-md">Fetching more…</span>)}
+      </div>
+    )
+  },
+}
+
+/**
+ * `scroll: 'page'` — the grid scrolls together with the nearest scrollable
+ * ancestor (here the bordered box, in a real app the `AppPage` content area), so
+ * the whole page expands and scrolls as one. The grid stays virtualized against
+ * that outer scroll container.
+ */
+export const pageScroll: Story = {
+  render: () => {
+    const { items, isFetching, loadMore } = useInfinitePages()
+    return (
+      <div className="max-h-128 overflow-y-auto rounded-lg border border-divider p-4 flex-col-4">
+        <div className="flex-row-2 items-center justify-between sticky top-0 bg-background py-2 z-10">
+          <span className="typography-title-md">Page scroll (outer container)</span>
+          <span className="text-description typography-label-md">{`${items.length} of ${TOTAL_ITEMS} loaded`}</span>
+        </div>
+        <p className="text-description typography-body-md">
+          The heading and this paragraph scroll away with the grid — the grid does not own its
+          own scroll box, it rides the outer scroll container.
+        </p>
+        <VirtualizedCardGrid<Item>
+          items={items}
+          getItemKey={(item) => item.id}
+          minCardWidthPx={280}
+          scroll="page"
+          onReachBottom={loadMore}
+          renderItem={(item) => <ItemCard key={item.id} item={item} />}
+        />
+        {isFetching && (<span className="text-description typography-label-md">Fetching more…</span>)}
+      </div>
+    )
+  },
+}
+
+/**
+ * Below `virtualizeThreshold` items the grid renders every card without
+ * virtualization, so small lists stay simple and fully present in the DOM.
+ */
+export const smallListNotVirtualized: Story = {
+  render: () => {
+    const items = useMemo(() => allItems.slice(0, 12), [])
+    return (
+      <div className="flex-col-2">
+        <span className="typography-title-md">Small list (not virtualized)</span>
+        <VirtualizedCardGrid<Item>
+          items={items}
+          getItemKey={(item) => item.id}
+          minCardWidthPx={280}
+          renderItem={(item) => <ItemCard key={item.id} item={item} />}
+        />
+      </div>
+    )
+  },
+}


### PR DESCRIPTION
Introduce a reusable virtualization scroll layer so a virtualized list can scroll together with the surrounding page (e.g. the AppPage content area) instead of inside its own capped box.

- Add `VirtualizationScroll` modes ('window' | 'container' | 'page') and a shared `useVirtualizedRows` hook that selects the right TanStack virtualizer, measures the content offset for outer-scroll modes, resolves the nearest scrollable ancestor for 'page' mode, and wires up `onReachBottom` for infinite scroll.
- Rework `VirtualizedTableBody` to use the shared hook and gain the 'page' mode plus a built-in `onReachBottom` option.
- Add a `VirtualizedCardGrid` component that shares the same scroll handling, so a card grid and a table behave identically inside one scroll region.
- Add stories for the card grid (container/page/small) and a page-scroll table.


Claude-Session: https://claude.ai/code/session_01375kAPxAFypUHbqWZmWkNF