### PR TITLE
fix: resolve AppPage scroll container for 'page' virtualization (0.13.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.13.1] - 2026-07-03
+
+### Fixed
+
+- `page` virtualization now binds to the `AppPage` content area directly, so a list whose data loads after mount no longer renders zero rows (previously the empty content never overflowed, so no scroll container was found and the virtualizer deadlocked)
+
 ## [0.13.0] - 2026-07-03
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@helpwave/hightide",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@helpwave/hightide",
-      "version": "0.13.0",
+      "version": "0.13.1",
       "license": "MPL-2.0",
       "dependencies": {
         "@helpwave/internationalization": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "access": "public"
   },
   "license": "MPL-2.0",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "files": [
     "dist"
   ],

--- a/src/components/layout/virtualization/useVirtualizedRows.ts
+++ b/src/components/layout/virtualization/useVirtualizedRows.ts
@@ -3,7 +3,7 @@ import { useEffect, useState } from 'react'
 import type { Virtualizer } from '@tanstack/react-virtual'
 import { useVirtualizer, useWindowVirtualizer } from '@tanstack/react-virtual'
 import {
-  findScrollableAncestor,
+  findPageScrollContainer,
   getScrollMetrics,
   isNearBottom,
   type VirtualizationScroll
@@ -72,7 +72,7 @@ export function useVirtualizedRows({
 
     const measure = () => {
       if (scroll === 'page') {
-        const container = findScrollableAncestor(content)
+        const container = findPageScrollContainer(content)
         setPageScrollElement(prev => (prev === container ? prev : container))
         const top = container
           ? content.getBoundingClientRect().top - container.getBoundingClientRect().top + container.scrollTop
@@ -92,7 +92,9 @@ export function useVirtualizedRows({
       resizeObserver.disconnect()
       window.removeEventListener('resize', measure)
     }
-  }, [scroll, usesOuterScroll, contentRef])
+    // `count` is included so the scroll container is re-resolved and the offset
+    // re-measured once rows arrive (data often loads after the first mount).
+  }, [scroll, usesOuterScroll, contentRef, count])
 
   const common = {
     count,

--- a/src/components/layout/virtualization/virtualizationScroll.ts
+++ b/src/components/layout/virtualization/virtualizationScroll.ts
@@ -31,6 +31,24 @@ export function findScrollableAncestor(element: HTMLElement | null): HTMLElement
   return null
 }
 
+/** Marks the {@link AppPage} content area — the scroll container for `'page'` mode. */
+export const APP_PAGE_CONTENT_SELECTOR = '[data-name="app-page-content"]'
+
+/**
+ * Resolves the scroll container for the `'page'` virtualization mode. Prefers the
+ * {@link AppPage} content area, which is a real scroll container regardless of how
+ * much content is currently loaded — resolving by overflow state alone would
+ * deadlock a virtualized list whose data arrives after mount (empty content →
+ * no overflow → no scroll element → no rows → still no overflow). Falls back to
+ * the nearest scrollable ancestor for non-AppPage contexts.
+ */
+export function findPageScrollContainer(element: HTMLElement | null): HTMLElement | null {
+  if (!element || typeof window === 'undefined') return null
+  const appPageContent = element.closest(APP_PAGE_CONTENT_SELECTOR)
+  if (appPageContent instanceof HTMLElement) return appPageContent
+  return findScrollableAncestor(element)
+}
+
 export type ScrollMetrics = {
   scrollTop: number,
   scrollHeight: number,

--- a/tests/virtualization/virtualizationScroll.test.ts
+++ b/tests/virtualization/virtualizationScroll.test.ts
@@ -1,0 +1,41 @@
+/**
+ * @jest-environment jsdom
+ */
+import { findPageScrollContainer, findScrollableAncestor } from '../../src/components/layout/virtualization/virtualizationScroll'
+
+describe('findPageScrollContainer', () => {
+  afterEach(() => {
+    document.body.innerHTML = ''
+  })
+
+  it('resolves the AppPage content area regardless of current overflow state', () => {
+    // jsdom has no layout, so scrollHeight === clientHeight === 0 everywhere:
+    // the AppPage container is not "currently overflowing", yet page-scroll
+    // virtualization must still bind to it (otherwise an empty list never
+    // resolves a scroll element and renders zero rows).
+    document.body.innerHTML = `
+      <div data-name="app-page-content">
+        <main>
+          <div id="list">
+            <table><tbody id="body"></tbody></table>
+          </div>
+        </main>
+      </div>
+    `
+    const body = document.getElementById('body')!
+    const appPageContent = document.querySelector('[data-name="app-page-content"]')
+
+    expect(findScrollableAncestor(body)).toBeNull()
+    expect(findPageScrollContainer(body)).toBe(appPageContent)
+  })
+
+  it('returns null when there is no AppPage container and nothing scrolls', () => {
+    document.body.innerHTML = '<div><table><tbody id="body"></tbody></table></div>'
+    const body = document.getElementById('body')!
+    expect(findPageScrollContainer(body)).toBeNull()
+  })
+
+  it('returns null for a null element', () => {
+    expect(findPageScrollContainer(null)).toBeNull()
+  })
+})


### PR DESCRIPTION
## What & why

Follow-up fix to #273. The new `'page'` virtualization mode resolved its scroll container via `findScrollableAncestor`, which requires `scrollHeight > clientHeight`. When a virtualized list's data loads **after** mount (the normal case in tasks), the content is briefly empty, nothing overflows, no scroll element is found, and the virtualizer renders **zero rows** — which keeps the content empty, so it never recovers. This is what broke all 9 e2e tests on helpwave/tasks#309 (empty patient table).

## Fix

- Add `findPageScrollContainer`: resolve the AppPage content area (`[data-name="app-page-content"]`) directly — it is a real scroll container regardless of how much content is currently loaded — and fall back to the nearest scrollable ancestor for non-AppPage contexts.
- `useVirtualizedRows` now uses it for `'page'` mode and re-resolves/re-measures when the row count changes, so late-arriving data recovers.
- Bump to **0.13.1** so the publish workflow releases the fix (helpwave/tasks#309 is pinned to it).

## Verification

- New unit test `tests/virtualization/virtualizationScroll.test.ts` reproduces the deadlock scenario (jsdom: no overflow anywhere) and asserts the AppPage container still resolves — passes.
- Full test suite passes (101 tests), typecheck + lint clean, `npm run build` succeeds and exports `findPageScrollContainer`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01375kAPxAFypUHbqWZmWkNF

---
_Generated by [Claude Code](https://claude.ai/code/session_01375kAPxAFypUHbqWZmWkNF)_