### PR TITLE
feat: natural column sizing, page-sticky table header, virtualizer gating (0.13.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.13.2] - 2026-07-03
+
+### Added
+
+- `columnSizingMode: 'natural'` on the table: disables the fill-the-container width negotiation so the browser's auto layout sizes columns to their content (respecting `minSize`); explicitly resized columns keep their width and drags start from the rendered width
+- `stickyScroll: 'page'` on the table header (auto-derived from the `'page'` virtualization mode): keeps the header visible while the surrounding page scrolls, offset below the AppPage header
+
+### Changed
+
+- Only the virtualizer matching the active scroll mode attaches scroll listeners and resize observers; `VirtualizedCardGrid` disables them entirely below its virtualization threshold
+
 ## [0.13.1] - 2026-07-03
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@helpwave/hightide",
-  "version": "0.13.1",
+  "version": "0.13.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@helpwave/hightide",
-      "version": "0.13.1",
+      "version": "0.13.2",
       "license": "MPL-2.0",
       "dependencies": {
         "@helpwave/internationalization": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "access": "public"
   },
   "license": "MPL-2.0",
-  "version": "0.13.1",
+  "version": "0.13.2",
   "files": [
     "dist"
   ],

--- a/src/components/layout/table/TableContext.tsx
+++ b/src/components/layout/table/TableContext.tsx
@@ -12,12 +12,15 @@ import type { ReactNode, RefObject } from 'react'
 import { createContext, useContext } from 'react'
 
 
+export type ColumnSizingMode = 'fill' | 'natural'
+
 export interface TableStateWithoutSizingContextType<T> extends Omit<TableState, 'columnSizing' | 'columnSizingInfo'> {
   table: ReactTable<T>,
   data: T[],
   columns: ColumnDef<T>[],
   rowModel: RowModel<T>,
   isUsingFillerRows: boolean,
+  columnSizingMode: ColumnSizingMode,
   fillerRowCell: (columnId: string, table: ReactTable<T>) => ReactNode,
   onRowClick?: (row: Row<T>, table: ReactTable<T>) => void,
   onFillerRowClick?: (index: number, table: ReactTable<T>) => void,
@@ -47,6 +50,7 @@ export interface TableStateContextType<T> extends TableState {
   columns: ColumnDef<T>[],
   rowModel: RowModel<T>,
   isUsingFillerRows: boolean,
+  columnSizingMode: ColumnSizingMode,
   fillerRowCell: (columnId: string, table: ReactTable<T>) => ReactNode,
   onRowClick?: (row: Row<T>, table: ReactTable<T>) => void,
   onFillerRowClick?: (index: number, table: ReactTable<T>) => void,

--- a/src/components/layout/table/TableDisplay.tsx
+++ b/src/components/layout/table/TableDisplay.tsx
@@ -27,7 +27,7 @@ export const TableDisplay = <T,>({
   virtualized = false,
   ...props
 }: TableDisplayProps) => {
-  const { table, targetWidth } = useTableStateContext<T>()
+  const { table, targetWidth, columnSizingMode } = useTableStateContext<T>()
   const { containerRef } = useTableContainerContext<T>()
   const tableRef = useRef<HTMLTableElement>(null)
   const scrollbarState = useScrollbarState({
@@ -35,6 +35,8 @@ export const TableDisplay = <T,>({
     contentRef: tableRef,
     isActive: !!virtualized,
   })
+
+  const virtualizedScroll = typeof virtualized === 'object' ? virtualized.scroll : undefined
 
   return (
     <div
@@ -47,14 +49,20 @@ export const TableDisplay = <T,>({
         {...props}
         ref={tableRef}
         data-name={props['data-name'] ?? 'table'}
+        data-column-sizing={columnSizingMode}
 
         style={{
-          width: Math.floor(Math.max(table.getTotalSize(), targetWidth ?? table.getTotalSize())),
+          ...(columnSizingMode === 'fill'
+            ? { width: Math.floor(Math.max(table.getTotalSize(), targetWidth ?? table.getTotalSize())) }
+            : {}),
           ...props.style,
         }}
       >
         {children}
-        <TableHeader {...tableHeaderProps} />
+        <TableHeader
+          {...tableHeaderProps}
+          stickyScroll={tableHeaderProps?.stickyScroll ?? (virtualizedScroll === 'page' ? 'page' : 'container')}
+        />
         {virtualized
           ? <VirtualizedTableBody {...(typeof virtualized === 'object' ? virtualized : {})} />
           : <TableBody />}

--- a/src/components/layout/table/TableHeader.tsx
+++ b/src/components/layout/table/TableHeader.tsx
@@ -4,16 +4,56 @@ import clsx from 'clsx'
 import { Visibility } from '../Visibility'
 import { TableSortButton } from './TableSortButton'
 import { TableFilterButton } from './TableFilterButton'
-import { useCallback, useEffect } from 'react'
+import { useCallback, useEffect, useRef } from 'react'
 import { TableStateContext, useTableStateWithoutSizingContext } from './TableContext'
 import { DataTypeUtils, type DataType } from '../../user-interaction/data/data-types'
+import { findPageScrollContainer } from '../virtualization/virtualizationScroll'
+import { MathUtil } from '@/src/utils/math'
 
 export type TableHeaderProps = {
   isSticky?: boolean,
+  stickyScroll?: 'container' | 'page',
 }
 
-export const TableHeader = ({ isSticky = false }: TableHeaderProps) => {
-  const { table } = useTableStateWithoutSizingContext<unknown>()
+export const TableHeader = ({ isSticky = false, stickyScroll = 'container' }: TableHeaderProps) => {
+  const { table, columnSizingMode } = useTableStateWithoutSizingContext<unknown>()
+  const theadRef = useRef<HTMLTableSectionElement>(null)
+  const usesPageSticky = isSticky && stickyScroll === 'page'
+  const isNaturalSizing = columnSizingMode === 'natural'
+
+  useEffect(() => {
+    if (!usesPageSticky || typeof window === 'undefined') return
+    const thead = theadRef.current
+    const tableElement = thead?.parentElement
+    if (!thead || !tableElement) return
+    const scrollElement = findPageScrollContainer(tableElement)
+    if (!scrollElement) return
+    const appPageHeader = scrollElement.querySelector('[data-name="app-page-header"]')
+
+    const update = () => {
+      const scrollRect = scrollElement.getBoundingClientRect()
+      const stickyTop = Math.max(
+        scrollRect.top,
+        appPageHeader ? appPageHeader.getBoundingClientRect().bottom : scrollRect.top
+      )
+      const tableRect = tableElement.getBoundingClientRect()
+      const maxShift = Math.max(0, tableRect.height - thead.offsetHeight)
+      const shift = MathUtil.clamp(stickyTop - tableRect.top, [0, maxShift])
+      thead.style.transform = shift > 0.5 ? `translate3d(0, ${shift}px, 0)` : ''
+    }
+
+    update()
+    const resizeObserver = new ResizeObserver(update)
+    resizeObserver.observe(tableElement)
+    scrollElement.addEventListener('scroll', update, { passive: true })
+    window.addEventListener('resize', update)
+    return () => {
+      resizeObserver.disconnect()
+      scrollElement.removeEventListener('scroll', update)
+      window.removeEventListener('resize', update)
+      thead.style.transform = ''
+    }
+  }, [usesPageSticky])
 
   const handleResizeMove = useCallback((e: MouseEvent | TouchEvent) => {
     if (!table.getState().columnSizingInfo.isResizingColumn) return
@@ -72,18 +112,22 @@ export const TableHeader = ({ isSticky = false }: TableHeaderProps) => {
               {headerGroup.headers.map(header => (
                 <col
                   key={header.id}
-                  style={{
-                    width: `calc(var(--header-${header?.id}-size) * 1px)`,
-                    minWidth: header.column.columnDef.minSize,
-                    maxWidth: header.column.columnDef.maxSize,
-                  }}
+                  style={isNaturalSizing
+                    ? (tableStateContext?.columnSizing?.[header.id] !== undefined
+                      ? { width: `calc(var(--header-${header?.id}-size) * 1px)` }
+                      : undefined)
+                    : {
+                      width: `calc(var(--header-${header?.id}-size) * 1px)`,
+                      minWidth: header.column.columnDef.minSize,
+                      maxWidth: header.column.columnDef.maxSize,
+                    }}
                 />
               ))}
             </colgroup>
           )}
         </TableStateContext.Consumer>
       ))}
-      <thead>
+      <thead ref={theadRef} data-name="table-header" data-sticky-page={PropsUtil.dataAttributes.bool(usesPageSticky)}>
         {table.getHeaderGroups().map(headerGroup => (
           <tr key={headerGroup.id} data-name="table-header-row" className={clsx(table.options.meta?.headerRowClassName)}>
             {headerGroup.headers.map(header => {
@@ -96,6 +140,7 @@ export const TableHeader = ({ isSticky = false }: TableHeaderProps) => {
                   data-sticky={isSticky ? '' : undefined}
                   data-name="table-header-cell"
                   className={clsx('group/table-header-cell', header.column.columnDef.meta?.className)}
+                  style={isNaturalSizing ? { minWidth: header.column.columnDef.minSize } : undefined}
                 >
                   <Visibility isVisible={!header.isPlaceholder}>
                     <div className="table-header-cell-content">
@@ -140,10 +185,12 @@ export const TableHeader = ({ isSticky = false }: TableHeaderProps) => {
                     <div
                       onPointerDown={(e) => {
                         const startX = e.clientX
+                        const renderedWidth = (e.currentTarget as HTMLElement).closest('th')?.getBoundingClientRect().width
                         table.setColumnSizingInfo({
                           columnSizingStart: Object.entries(table.getState().columnSizing),
                           startOffset: startX,
-                          startSize: table.getState().columnSizing[header.column.id] ?? 0,
+                          startSize: table.getState().columnSizing[header.column.id]
+                            ?? (renderedWidth !== undefined ? Math.round(renderedWidth) : header.getSize()),
                           deltaOffset: 0,
                           deltaPercentage: null,
                           isResizingColumn: header.column.id,

--- a/src/components/layout/table/TableProvider.tsx
+++ b/src/components/layout/table/TableProvider.tsx
@@ -2,7 +2,7 @@ import type { ReactNode } from 'react'
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
 import { useEventCallbackStabilizer } from '@/src/hooks/useEventCallbackStabelizer'
 import { ColumnSizeUtil } from './columnSizeUtil'
-import type { TableColumnDefinitionContextType, TableContainerContextType, TableStateWithoutSizingContextType } from './TableContext'
+import type { ColumnSizingMode, TableColumnDefinitionContextType, TableContainerContextType, TableStateWithoutSizingContextType } from './TableContext'
 import { TableColumnDefinitionContext, TableContainerContext, TableStateContext, TableStateWithoutSizingContext } from './TableContext'
 import { TableFilter } from './TableFilter'
 import type { ColumnDef, InitialTableState, Row, TableOptions, TableState , Table as ReactTable, CellContext, Table } from '@tanstack/react-table'
@@ -21,6 +21,7 @@ export type TableProviderProps<T> = {
   children?: ReactNode,
   placeholderColumnExcludeIds?: string[],
   isUsingFillerRows?: boolean,
+  columnSizingMode?: ColumnSizingMode,
   fillerRowCell?: (columnId: string, table: ReactTable<T>) => ReactNode,
   initialState?: InitialTableState,
   onRowClick?: (row: Row<T>, table: ReactTable<T>) => void,
@@ -31,6 +32,7 @@ export type TableProviderProps<T> = {
 export const TableProvider = <T,>({
   data,
   isUsingFillerRows = true,
+  columnSizingMode = 'fill',
   fillerRowCell: fillerRowCellOverwrite,
   initialState,
   onRowClick,
@@ -74,6 +76,7 @@ export const TableProvider = <T,>({
     },
   })
 
+  const negotiatesWidths = columnSizingMode === 'fill'
   const [targetWidth, setTargetWidth] =  useState<number | undefined>(undefined)
   const computeWidth = useCallback(() => {
     const el = containerRef?.current
@@ -85,11 +88,13 @@ export const TableProvider = <T,>({
     return Math.floor(width)
   }, [containerRef])
   useLayoutEffect(() => {
+    if(!negotiatesWidths) return
     setTargetWidth(computeWidth())
-  }, [computeWidth])
+  }, [computeWidth, negotiatesWidths])
   useWindowResizeObserver(useCallback(() => {
+    if(!negotiatesWidths) return
     setTargetWidth(computeWidth())
-  }, [computeWidth]))
+  }, [computeWidth, negotiatesWidths]))
 
   const registerColumn = useCallback((column: ColumnDef<T>) => {
     setRegisteredColumns(prev => {
@@ -173,7 +178,7 @@ export const TableProvider = <T,>({
       ColumnSizingWithTargetFeature,
       AutoColumnOrderFeature,
     ],
-    columnSizingTarget: targetWidth,
+    columnSizingTarget: negotiatesWidths ? targetWidth : undefined,
     autoResetPageIndex: false,
     enableColumnResizing: true,
     columnResizeMode: 'onChange',
@@ -232,6 +237,7 @@ export const TableProvider = <T,>({
   const tableStateWithoutSizingContextValue = useMemo<TableStateWithoutSizingContextType<T>>(() => ({
     table,
     isUsingFillerRows,
+    columnSizingMode,
     fillerRowCell,
     onRowClick: onRowClickStable,
     onFillerRowClick: onFillerRowClickStable,
@@ -255,6 +261,7 @@ export const TableProvider = <T,>({
     columns,
     rowModel,
     isUsingFillerRows,
+    columnSizingMode,
     fillerRowCell,
     onRowClickStable,
     onFillerRowClickStable,

--- a/src/components/layout/virtualization/VirtualizedCardGrid.tsx
+++ b/src/components/layout/virtualization/VirtualizedCardGrid.tsx
@@ -81,6 +81,7 @@ export function VirtualizedCardGrid<T>({
     count: rows.length,
     estimateRowHeight: estimateRowHeightPx,
     overscan: overscanRows,
+    enabled: items.length > virtualizeThreshold,
     getItemKey: (index) => {
       const first = rows[index]?.[0]
       return first ? getItemKey(first) : index

--- a/src/components/layout/virtualization/useVirtualizedRows.ts
+++ b/src/components/layout/virtualization/useVirtualizedRows.ts
@@ -14,6 +14,7 @@ export type UseVirtualizedRowsOptions = {
   count: number,
   estimateRowHeight: number,
   overscan: number,
+  enabled?: boolean,
   getItemKey?: (index: number) => Key,
   /**
    * The element whose top marks where the virtualized content starts (e.g. the
@@ -48,6 +49,7 @@ export function useVirtualizedRows({
   count,
   estimateRowHeight,
   overscan,
+  enabled = true,
   getItemKey,
   contentRef,
   containerRef,
@@ -102,9 +104,9 @@ export function useVirtualizedRows({
     overscan,
     ...(getItemKey ? { getItemKey } : {}),
   }
-  const windowVirtualizer = useWindowVirtualizer({ ...common, scrollMargin })
-  const containerVirtualizer = useVirtualizer({ ...common, getScrollElement: () => containerRef?.current ?? null })
-  const pageVirtualizer = useVirtualizer({ ...common, getScrollElement: () => pageScrollElement, scrollMargin })
+  const windowVirtualizer = useWindowVirtualizer({ ...common, scrollMargin, enabled: enabled && scroll === 'window' })
+  const containerVirtualizer = useVirtualizer({ ...common, getScrollElement: () => containerRef?.current ?? null, enabled: enabled && scroll === 'container' })
+  const pageVirtualizer = useVirtualizer({ ...common, getScrollElement: () => pageScrollElement, scrollMargin, enabled: enabled && scroll === 'page' })
 
   const virtualizer = (
     scroll === 'window'

--- a/src/style/theme/components/table.css
+++ b/src/style/theme/components/table.css
@@ -19,6 +19,16 @@
   [data-name="table"] {
     @apply table-fixed border-separate border-spacing-0;
     @apply bg-table-background text-table-text;
+
+    &[data-column-sizing="natural"] {
+      @apply table-auto w-full;
+    }
+  }
+
+  [data-name="table-header"] {
+    @media print {
+      transform: none !important;
+    }
   }
 
   [data-name="table-filler-cell"] {

--- a/stories/Layout/Table/NaturalColumnSizing.stories.tsx
+++ b/stories/Layout/Table/NaturalColumnSizing.stories.tsx
@@ -1,0 +1,71 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite'
+import { useCallback, useState } from 'react'
+import { faker } from '@faker-js/faker'
+import { range } from '@/src/utils/array'
+import { Table } from '@/src/components/layout/table/Table'
+import { TableColumn } from '@/src/components/layout/table/TableColumn'
+import { Button } from '@/src/components/user-interaction/Button'
+import { Chip } from '@/src/components/display-and-visualization/Chip'
+
+type Row = {
+  id: string,
+  name: string,
+  grade: string,
+  city: string,
+  note: string,
+}
+
+faker.seed(20260703)
+
+const makeRow = (index: number, wide: boolean): Row => ({
+  id: String(index + 1),
+  name: faker.person.fullName(),
+  grade: wide ? faker.helpers.arrayElement(['Level II-b', 'Stage III (critical)', 'A+']) : faker.helpers.arrayElement(['1', '2', '3']),
+  city: faker.location.city(),
+  note: wide ? faker.lorem.sentence() : faker.lorem.words(2),
+})
+
+const meta: Meta = {}
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const naturalColumnSizing: Story = {
+  render: () => {
+    const [rows, setRows] = useState<Row[]>(() => range(8).map((index) => makeRow(index, false)))
+
+    const addWideRows = useCallback(() => {
+      setRows(prev => [...prev, ...range([prev.length, prev.length + 4]).map((index) => makeRow(index, true))])
+    }, [])
+
+    return (
+      <Table
+        table={{
+          data: rows,
+          columnSizingMode: 'natural',
+          isUsingFillerRows: false,
+          initialState: { pagination: { pageIndex: 0, pageSize: 1000 } },
+        }}
+        paginationOptions={{ showPagination: false }}
+        header={(
+          <div className="flex-row-2 items-center justify-between w-full">
+            <span className="typography-title-md">Natural column sizing</span>
+            <Button onClick={addWideRows}>Load wider content</Button>
+          </div>
+        )}
+      >
+        <TableColumn id="id" header="ID" accessorKey="id" minSize={48}/>
+        <TableColumn
+          id="grade"
+          header="Grade"
+          accessorKey="grade"
+          minSize={48}
+          cell={({ cell }) => (<Chip size="sm">{cell.getValue() as string}</Chip>)}
+        />
+        <TableColumn id="name" header="Name" accessorKey="name" minSize={120}/>
+        <TableColumn id="city" header="City" accessorKey="city" minSize={96}/>
+        <TableColumn id="note" header="Note" accessorKey="note" minSize={120}/>
+      </Table>
+    )
+  },
+}

--- a/stories/Layout/Table/PageScrollTable.stories.tsx
+++ b/stories/Layout/Table/PageScrollTable.stories.tsx
@@ -87,6 +87,7 @@ export const pageScrollTable: Story = {
           paginationOptions={{ showPagination: false }}
           displayProps={{
             virtualized: { scroll: 'page', estimateRowHeight: 48, onReachBottom: fetchNextPage },
+            tableHeaderProps: { isSticky: true },
           }}
           footer={isFetching ? (
             <span className="text-description typography-label-md">Fetching more…</span>

--- a/tests/table/naturalColumnSizing.test.tsx
+++ b/tests/table/naturalColumnSizing.test.tsx
@@ -1,0 +1,63 @@
+/**
+ * @jest-environment jsdom
+ */
+import { render } from '@testing-library/react'
+import { LocaleContext } from '../../src/global-contexts/LocaleContext'
+import { Table } from '../../src/components/layout/table/Table'
+import { TableColumn } from '../../src/components/layout/table/TableColumn'
+
+type Row = { id: string, name: string, grade: string }
+
+const DATA: Row[] = [
+  { id: '1', name: 'Alice Doe', grade: 'A' },
+  { id: '2', name: 'Bob Roe', grade: '2' },
+]
+
+const renderTable = (columnSizingMode?: 'fill' | 'natural') => render(
+  <LocaleContext.Provider value={{ locale: 'en-US', setLocale: () => {} }}>
+    <Table
+      table={{ data: DATA, columnSizingMode, isUsingFillerRows: false }}
+      paginationOptions={{ showPagination: false }}
+    >
+      <TableColumn<Row> id="name" header="Name" accessorKey="name" minSize={120}/>
+      <TableColumn<Row> id="grade" header="Grade" accessorKey="grade" minSize={48}/>
+    </Table>
+  </LocaleContext.Provider>
+)
+
+describe('table column sizing modes', () => {
+  it('tags the table element with the active sizing mode', () => {
+    const { container, unmount } = renderTable('natural')
+    expect(container.querySelector('table[data-name="table"]')?.getAttribute('data-column-sizing')).toBe('natural')
+    unmount()
+
+    const { container: fillContainer } = renderTable()
+    expect(fillContainer.querySelector('table[data-name="table"]')?.getAttribute('data-column-sizing')).toBe('fill')
+  })
+
+  it('natural mode sets no explicit column widths, keeping content in charge', () => {
+    const { container } = renderTable('natural')
+    const cols = Array.from(container.querySelectorAll('col'))
+    expect(cols.length).toBeGreaterThan(0)
+    for (const col of cols) {
+      expect(col.style.width).toBe('')
+    }
+    const ths = Array.from(container.querySelectorAll('th'))
+    expect(ths.some(th => th.style.minWidth === '120px')).toBe(true)
+  })
+
+  it('natural mode sets no explicit width on the table element', () => {
+    const { container } = renderTable('natural')
+    const table = container.querySelector('table[data-name="table"]') as HTMLTableElement
+    expect(table.style.width).toBe('')
+  })
+
+  it('fill mode keeps the negotiated explicit widths', () => {
+    const { container } = renderTable()
+    const cols = Array.from(container.querySelectorAll('col'))
+    expect(cols.length).toBeGreaterThan(0)
+    for (const col of cols) {
+      expect(col.style.width).toContain('var(--header-')
+    }
+  })
+})


### PR DESCRIPTION
## What & why

Three table improvements for the page-scrolling lists in tasks:

- **`columnSizingMode: 'natural'`** — opts a table out of the fill-the-container width negotiation. The browser's auto table layout sizes each column to its content (respecting `minSize`, which moves onto the header cells since auto layout ignores `<col>` min-width), so a column holding one-character values stays narrow and widens as wider values load in. Dragging a resize handle still pins a column to an explicit width, and the drag now starts from the rendered width instead of `0` when no sizing entry exists.
- **Sticky header under page scroll** — `tableHeaderProps.isSticky` now also works with the `'page'` virtualization mode (auto-derived, overridable via `stickyScroll`). CSS `position: sticky` cannot escape the table's horizontal scroll wrapper, so the `thead` is translated along with the page scroll container, offset below the AppPage header, and reset for print.
- **Virtualizer gating** — only the virtualizer matching the active scroll mode attaches scroll listeners and resize observers (previously all three ran); `VirtualizedCardGrid` disables them entirely below its virtualization threshold.

Bumps to **0.13.2** (helpwave/tasks will pin it).

## Verification

- New unit tests for the sizing modes (`tests/table/naturalColumnSizing.test.tsx`); full suite passes (105 tests), typecheck + lint clean, build succeeds.
- New `NaturalColumnSizing` story; `PageScrollTable` story now exercises the sticky header.
- Verified end-to-end against helpwave/tasks with a local build: all 28 tasks e2e tests pass, including new sticky-header/print/natural-sizing tests (helpwave/tasks#312).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01375kAPxAFypUHbqWZmWkNF