### PR TITLE
fix: opaque page-sticky table header above positioned cell content (0.13.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.13.4] - 2026-07-03
+
+### Fixed
+
+- Page-sticky table headers no longer show the rows underneath them: the translated `thead` now stacks above positioned cell content (buttons, selects), so its opaque header background covers the rows it slides over
+
 ## [0.13.2] - 2026-07-03
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@helpwave/hightide",
-  "version": "0.13.2",
+  "version": "0.13.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@helpwave/hightide",
-      "version": "0.13.2",
+      "version": "0.13.4",
       "license": "MPL-2.0",
       "dependencies": {
         "@helpwave/internationalization": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "access": "public"
   },
   "license": "MPL-2.0",
-  "version": "0.13.2",
+  "version": "0.13.4",
   "files": [
     "dist"
   ],

--- a/src/style/theme/components/table.css
+++ b/src/style/theme/components/table.css
@@ -26,6 +26,10 @@
   }
 
   [data-name="table-header"] {
+    &[data-sticky-page] {
+      @apply relative z-10;
+    }
+
     @media print {
       transform: none !important;
     }


### PR DESCRIPTION
## Problem

With the page-scroll sticky header introduced in 0.13.2, the header looked transparent while scrolling: row text, buttons, and selects showed through it.

The header background itself was always opaque. The actual cause is stacking order: the page-sticky `thead` is shifted down with a `transform`, which creates a stacking context and traps the header cells' `z-index: 10` inside it. The `thead` itself then participated at `z-index: auto` alongside positioned content inside the body cells (edit buttons, selects, etc.), and since the body comes later in the DOM, that content painted on top of the translated header.

## Fix

`[data-name="table-header"][data-sticky-page]` now gets `position: relative; z-index: 10`, so the translated header participates in the surrounding stacking order above the rows it slides over — matching the `z-index: 10` the header cells already use in container-sticky mode.

Reproduced and verified in Chromium with the exact table CSS structure (border-separate table, translated `thead`, sticky header cells, positioned cell content): before the change the row content paints over the header; after it the header covers the rows.

- Version bumped to 0.13.4 with a changelog entry
- Tests (105) and lint pass; the compiled `globals.css` contains the new rule

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012mpEpBWtQJiTDEw3U3BGez

---
_Generated by [Claude Code](https://claude.ai/code/session_012mpEpBWtQJiTDEw3U3BGez)_