### PR TITLE
perf: CSS sticky table headers, memoized virtualized rows, locked natural column widths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.13.5] - 2026-07-04
+
+### Changed
+
+- Sticky table headers are now pure CSS (`position: sticky`) in every scroll mode: the `AppPage` header moved out of the scroll container (new `app-page-body` wrapper) and page-scroll table containers no longer create their own scrollport, removing the per-scroll-event JS repositioning (`getBoundingClientRect` + `transform`) that lagged behind fast scrolling
+- Virtualized table rows and card-grid rows are memoized, so the re-render the virtualizer triggers on every scroll frame only reconciles the row list instead of re-rendering every visible cell
+- Infinite scroll (`onReachBottom`) is derived from the virtualizer's rendered range instead of an extra scroll listener, removing per-scroll-event forced layout reads (`scrollHeight`/`clientHeight`)
+- Inactive virtualizer instances get a zero item count so they no longer hold measurement caches for the full row set
+- Naturally sized (`columnSizingMode: 'natural'`) virtualized tables lock their measured column widths once rows are rendered (`data-natural-locked`, fixed table layout), so virtual row swaps no longer re-run the full-table auto layout or make the header shift; widths re-measure on viewport resize and user-resized columns keep their width
+
+### Removed
+
+- `stickyScroll` prop on `TableHeader` (obsolete: sticky headers no longer need JS positioning)
+
 ## [0.13.4] - 2026-07-03
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@ and adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Infinite scroll (`onReachBottom`) is derived from the virtualizer's rendered range instead of an extra scroll listener, removing per-scroll-event forced layout reads (`scrollHeight`/`clientHeight`)
 - Inactive virtualizer instances get a zero item count so they no longer hold measurement caches for the full row set
 - Naturally sized (`columnSizingMode: 'natural'`) virtualized tables lock their measured column widths once rows are rendered (`data-natural-locked`, fixed table layout), so virtual row swaps no longer re-run the full-table auto layout or make the header shift; widths re-measure on viewport resize and user-resized columns keep their width
+- Column resize drags are clamped to the column's `minSize` (users can widen resizable columns freely but can no longer drag them below their minimum width), track the pointer without the previous one-event lag, and batch their table-state updates per animation frame instead of per pointermove
+
+### Fixed
+
+- Column resize drags no longer freeze mid-gesture: the resize handle now captures the pointer and prevents the browser's default press behaviour, so a native text-selection drag (started from previously selected header text) can no longer cancel the pointer stream after the first move
+- Row measurement (`ResizeObserver`) is batched into animation frames and scroll-idle detection uses the native `scrollend` event where available
 
 ### Removed
 

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "access": "public"
   },
   "license": "MPL-2.0",
-  "version": "0.13.4",
+  "version": "0.13.5",
   "files": [
     "dist"
   ],

--- a/src/components/layout/app/AppPage.tsx
+++ b/src/components/layout/app/AppPage.tsx
@@ -210,7 +210,7 @@ export const AppPage = ({
         activeId={resolvedActiveId}
         LinkComponent={sidebarProps.LinkComponent}
       />
-      <div data-name="app-page-content" data-no-scrolling={noScrolling ? '' : undefined}>
+      <div data-name="app-page-body">
         <header data-name="app-page-header">
           <IconButton
             className="app-page-menu-button"
@@ -222,10 +222,12 @@ export const AppPage = ({
           </IconButton>
           {headerActions}
         </header>
-        <main data-name="app-page-main-content" data-outer-no-scrolling={noScrolling ? '' : undefined}>
-          {children}
-          {hasSpacer && (<div className="app-page-main-spacer" />)}
-        </main>
+        <div data-name="app-page-content" data-no-scrolling={noScrolling ? '' : undefined}>
+          <main data-name="app-page-main-content" data-outer-no-scrolling={noScrolling ? '' : undefined}>
+            {children}
+            {hasSpacer && (<div className="app-page-main-spacer" />)}
+          </main>
+        </div>
       </div>
     </div>
   )

--- a/src/components/layout/table/TableDisplay.tsx
+++ b/src/components/layout/table/TableDisplay.tsx
@@ -8,6 +8,7 @@ import { useTableContainerContext, useTableStateContext } from './TableContext'
 import type { TableVirtualizationOptions } from './VirtualizedTableBody'
 import { VirtualizedTableBody } from './VirtualizedTableBody'
 import { useScrollbarState } from '@/src/hooks/useScrollbarState'
+import { useNaturalColumnWidthLock } from './useNaturalColumnWidthLock'
 
 export interface TableDisplayProps extends TableHTMLAttributes<HTMLTableElement> {
   'containerProps'?: Omit<React.HTMLAttributes<HTMLDivElement>, 'children'> & { 'data-name'?: string },
@@ -30,13 +31,18 @@ export const TableDisplay = <T,>({
   const { table, targetWidth, columnSizingMode } = useTableStateContext<T>()
   const { containerRef } = useTableContainerContext<T>()
   const tableRef = useRef<HTMLTableElement>(null)
+  const virtualizedScroll = typeof virtualized === 'object' ? virtualized.scroll : undefined
+  const usesPageScroll = virtualizedScroll === 'page' || virtualizedScroll === 'window'
   const scrollbarState = useScrollbarState({
     containerRef,
     contentRef: tableRef,
-    isActive: !!virtualized,
+    isActive: !!virtualized && !usesPageScroll,
   })
-
-  const virtualizedScroll = typeof virtualized === 'object' ? virtualized.scroll : undefined
+  const isNaturalWidthLocked = useNaturalColumnWidthLock({
+    table,
+    tableRef,
+    enabled: columnSizingMode === 'natural' && !!virtualized,
+  })
 
   return (
     <div
@@ -44,12 +50,14 @@ export const TableDisplay = <T,>({
       ref={containerRef}
       data-name={containerProps?.['data-name'] ?? 'table-container'}
       data-scrollbar={scrollbarState}
+      data-page-scroll={usesPageScroll ? '' : undefined}
     >
       <table
         {...props}
         ref={tableRef}
         data-name={props['data-name'] ?? 'table'}
         data-column-sizing={columnSizingMode}
+        data-natural-locked={isNaturalWidthLocked ? '' : undefined}
 
         style={{
           ...(columnSizingMode === 'fill'
@@ -59,10 +67,7 @@ export const TableDisplay = <T,>({
         }}
       >
         {children}
-        <TableHeader
-          {...tableHeaderProps}
-          stickyScroll={tableHeaderProps?.stickyScroll ?? (virtualizedScroll === 'page' ? 'page' : 'container')}
-        />
+        <TableHeader {...tableHeaderProps} />
         {virtualized
           ? <VirtualizedTableBody {...(typeof virtualized === 'object' ? virtualized : {})} />
           : <TableBody />}

--- a/src/components/layout/table/TableHeader.tsx
+++ b/src/components/layout/table/TableHeader.tsx
@@ -4,56 +4,17 @@ import clsx from 'clsx'
 import { Visibility } from '../Visibility'
 import { TableSortButton } from './TableSortButton'
 import { TableFilterButton } from './TableFilterButton'
-import { useCallback, useEffect, useRef } from 'react'
+import { useCallback, useEffect } from 'react'
 import { TableStateContext, useTableStateWithoutSizingContext } from './TableContext'
 import { DataTypeUtils, type DataType } from '../../user-interaction/data/data-types'
-import { findPageScrollContainer } from '../virtualization/virtualizationScroll'
-import { MathUtil } from '@/src/utils/math'
 
 export type TableHeaderProps = {
   isSticky?: boolean,
-  stickyScroll?: 'container' | 'page',
 }
 
-export const TableHeader = ({ isSticky = false, stickyScroll = 'container' }: TableHeaderProps) => {
+export const TableHeader = ({ isSticky = false }: TableHeaderProps) => {
   const { table, columnSizingMode } = useTableStateWithoutSizingContext<unknown>()
-  const theadRef = useRef<HTMLTableSectionElement>(null)
-  const usesPageSticky = isSticky && stickyScroll === 'page'
   const isNaturalSizing = columnSizingMode === 'natural'
-
-  useEffect(() => {
-    if (!usesPageSticky || typeof window === 'undefined') return
-    const thead = theadRef.current
-    const tableElement = thead?.parentElement
-    if (!thead || !tableElement) return
-    const scrollElement = findPageScrollContainer(tableElement)
-    if (!scrollElement) return
-    const appPageHeader = scrollElement.querySelector('[data-name="app-page-header"]')
-
-    const update = () => {
-      const scrollRect = scrollElement.getBoundingClientRect()
-      const stickyTop = Math.max(
-        scrollRect.top,
-        appPageHeader ? appPageHeader.getBoundingClientRect().bottom : scrollRect.top
-      )
-      const tableRect = tableElement.getBoundingClientRect()
-      const maxShift = Math.max(0, tableRect.height - thead.offsetHeight)
-      const shift = MathUtil.clamp(stickyTop - tableRect.top, [0, maxShift])
-      thead.style.transform = shift > 0.5 ? `translate3d(0, ${shift}px, 0)` : ''
-    }
-
-    update()
-    const resizeObserver = new ResizeObserver(update)
-    resizeObserver.observe(tableElement)
-    scrollElement.addEventListener('scroll', update, { passive: true })
-    window.addEventListener('resize', update)
-    return () => {
-      resizeObserver.disconnect()
-      scrollElement.removeEventListener('scroll', update)
-      window.removeEventListener('resize', update)
-      thead.style.transform = ''
-    }
-  }, [usesPageSticky])
 
   const handleResizeMove = useCallback((e: MouseEvent | TouchEvent) => {
     if (!table.getState().columnSizingInfo.isResizingColumn) return
@@ -127,7 +88,7 @@ export const TableHeader = ({ isSticky = false, stickyScroll = 'container' }: Ta
           )}
         </TableStateContext.Consumer>
       ))}
-      <thead ref={theadRef} data-name="table-header" data-sticky-page={PropsUtil.dataAttributes.bool(usesPageSticky)}>
+      <thead data-name="table-header">
         {table.getHeaderGroups().map(headerGroup => (
           <tr key={headerGroup.id} data-name="table-header-row" className={clsx(table.options.meta?.headerRowClassName)}>
             {headerGroup.headers.map(header => {

--- a/src/components/layout/table/TableHeader.tsx
+++ b/src/components/layout/table/TableHeader.tsx
@@ -4,7 +4,7 @@ import clsx from 'clsx'
 import { Visibility } from '../Visibility'
 import { TableSortButton } from './TableSortButton'
 import { TableFilterButton } from './TableFilterButton'
-import { useCallback, useEffect } from 'react'
+import { useCallback, useEffect, useRef } from 'react'
 import { TableStateContext, useTableStateWithoutSizingContext } from './TableContext'
 import { DataTypeUtils, type DataType } from '../../user-interaction/data/data-types'
 
@@ -15,36 +15,44 @@ export type TableHeaderProps = {
 export const TableHeader = ({ isSticky = false }: TableHeaderProps) => {
   const { table, columnSizingMode } = useTableStateWithoutSizingContext<unknown>()
   const isNaturalSizing = columnSizingMode === 'natural'
+  const resizeFrameRef = useRef<number | null>(null)
+  const resizePointerXRef = useRef(0)
+
+  const minColumnWidth = useCallback((columnId: string): number => {
+    const column = table.getColumn(columnId)
+    return column?.columnDef.minSize ?? table.options.defaultColumn?.minSize ?? 20
+  }, [table])
+
+  const applyResize = useCallback(() => {
+    const info = table.getState().columnSizingInfo
+    const columnId = info.isResizingColumn
+    if (!columnId) return
+    const deltaOffset = resizePointerXRef.current - (info.startOffset ?? 0)
+    const newWidth = Math.max(minColumnWidth(columnId), (info.startSize ?? 0) + deltaOffset)
+    table.setColumnSizing(prev => (prev[columnId] === newWidth ? prev : { ...prev, [columnId]: newWidth }))
+    table.setColumnSizingInfo(prev => ({ ...prev, deltaOffset }))
+  }, [table, minColumnWidth])
 
   const handleResizeMove = useCallback((e: MouseEvent | TouchEvent) => {
     if (!table.getState().columnSizingInfo.isResizingColumn) return
-    const currentX = 'touches' in e ? e.touches[0].clientX : e.clientX
-    const deltaOffset = currentX - (table.getState().columnSizingInfo.startOffset ?? 0)
-
-    const newWidth = (table.getState().columnSizingInfo.startSize ?? 0) + (table.getState().columnSizingInfo.deltaOffset ?? 0)
-
-    table.setColumnSizing(prev => {
-      return {
-        ...prev,
-        [table.getState().columnSizingInfo.isResizingColumn as string]: newWidth,
-      }
+    resizePointerXRef.current = 'touches' in e ? e.touches[0].clientX : e.clientX
+    if (resizeFrameRef.current !== null) return
+    resizeFrameRef.current = window.requestAnimationFrame(() => {
+      resizeFrameRef.current = null
+      applyResize()
     })
-    table.setColumnSizingInfo((prev) => ({
-      ...prev,
-      deltaOffset,
-    }))
-  }, [table])
+  }, [table, applyResize])
 
-  const handleResizeEnd = useCallback(() => {
+  const handleResizeEnd = useCallback((e: PointerEvent) => {
     if (!table.getState().columnSizingInfo.isResizingColumn) return
-    const newWidth = (table.getState().columnSizingInfo.startSize ?? 0) + (table.getState().columnSizingInfo.deltaOffset ?? 0)
-
-    table.setColumnSizing(prev => {
-      return {
-        ...prev,
-        [table.getState().columnSizingInfo.isResizingColumn as string]: newWidth,
-      }
-    })
+    if (typeof e.clientX === 'number' && e.clientX !== 0) {
+      resizePointerXRef.current = e.clientX
+    }
+    if (resizeFrameRef.current !== null) {
+      window.cancelAnimationFrame(resizeFrameRef.current)
+      resizeFrameRef.current = null
+    }
+    applyResize()
     table.setColumnSizingInfo({
       columnSizingStart: [],
       deltaOffset: null,
@@ -53,7 +61,7 @@ export const TableHeader = ({ isSticky = false }: TableHeaderProps) => {
       startOffset: null,
       startSize: null,
     })
-  }, [table])
+  }, [table, applyResize])
 
   useEffect(() => {
     window.addEventListener('pointermove', handleResizeMove)
@@ -61,6 +69,10 @@ export const TableHeader = ({ isSticky = false }: TableHeaderProps) => {
     return () => {
       window.removeEventListener('pointermove', handleResizeMove)
       window.removeEventListener('pointerup', handleResizeEnd)
+      if (resizeFrameRef.current !== null) {
+        window.cancelAnimationFrame(resizeFrameRef.current)
+        resizeFrameRef.current = null
+      }
     }
   }, [handleResizeEnd, handleResizeMove, table])
 
@@ -145,7 +157,11 @@ export const TableHeader = ({ isSticky = false }: TableHeaderProps) => {
                   <Visibility isVisible={header.column.getCanResize()}>
                     <div
                       onPointerDown={(e) => {
+                        e.preventDefault()
+                        e.currentTarget.setPointerCapture(e.pointerId)
+                        window.getSelection()?.removeAllRanges()
                         const startX = e.clientX
+                        resizePointerXRef.current = startX
                         const renderedWidth = (e.currentTarget as HTMLElement).closest('th')?.getBoundingClientRect().width
                         table.setColumnSizingInfo({
                           columnSizingStart: Object.entries(table.getState().columnSizing),

--- a/src/components/layout/table/VirtualizedTableBody.tsx
+++ b/src/components/layout/table/VirtualizedTableBody.tsx
@@ -1,6 +1,5 @@
-import type { Key } from 'react'
-import { useRef } from 'react'
-import type { Row } from '@tanstack/react-table'
+import { memo, useRef } from 'react'
+import type { Cell, Row, Table } from '@tanstack/react-table'
 import { flexRender } from '@tanstack/react-table'
 import clsx from 'clsx'
 import { useTableContainerContext, useTableStateWithoutSizingContext } from './TableContext'
@@ -21,6 +20,42 @@ export type TableVirtualizationOptions = {
 }
 
 export type VirtualizedTableBodyProps = TableVirtualizationOptions
+
+type VirtualizedTableRowProps = {
+  row: Row<unknown>,
+  cells: Cell<unknown, unknown>[],
+  table: Table<unknown>,
+  dataIndex?: number,
+  measureRef?: (node: Element | null) => void,
+  onRowClick?: (row: Row<unknown>, table: Table<unknown>) => void,
+  className?: string,
+}
+
+const VirtualizedTableRow = memo(({
+  row,
+  cells,
+  table,
+  dataIndex,
+  measureRef,
+  onRowClick,
+  className,
+}: VirtualizedTableRowProps) => (
+  <tr
+    data-index={dataIndex}
+    ref={measureRef}
+    onClick={onRowClick ? () => onRowClick(row, table) : undefined}
+    data-clickable={PropsUtil.dataAttributes.bool(!!onRowClick)}
+    data-name="table-body-row"
+    className={className}
+  >
+    {cells.map(cell => (
+      <td key={cell.id} data-name="table-body-cell" className={clsx(cell.column.columnDef.meta?.className)}>
+        {flexRender(cell.column.columnDef.cell, cell.getContext())}
+      </td>
+    ))}
+  </tr>
+))
+VirtualizedTableRow.displayName = 'VirtualizedTableRow'
 
 export const VirtualizedTableBody = ({
   estimateRowHeight = 48,
@@ -47,27 +82,24 @@ export const VirtualizedTableBody = ({
     reachBottomThresholdPx,
   })
 
-  const renderRow = (row: Row<unknown>, key: Key, measured: boolean, dataIndex?: number) => (
-    <tr
-      key={key}
-      data-index={dataIndex}
-      ref={measured ? virtualizer.measureElement : undefined}
-      onClick={() => onRowClick?.(row, table)}
-      data-clickable={PropsUtil.dataAttributes.bool(!!onRowClick)}
-      data-name="table-body-row"
-      className={clsx(BagFunctionUtil.resolve(table.options.meta?.bodyRowClassName, row.original))}
-    >
-      {row.getVisibleCells().map(cell => (
-        <td key={cell.id} data-name="table-body-cell" className={clsx(cell.column.columnDef.meta?.className)}>
-          {flexRender(cell.column.columnDef.cell, cell.getContext())}
-        </td>
-      ))}
-    </tr>
+  const bodyRowClassName = table.options.meta?.bodyRowClassName
+  const renderRow = (row: Row<unknown>, measured: boolean, dataIndex?: number) => (
+    <VirtualizedTableRow
+      key={row.id}
+      row={row}
+      cells={row.getVisibleCells()}
+      table={table}
+      dataIndex={dataIndex}
+      measureRef={measured ? virtualizer.measureElement : undefined}
+      onRowClick={onRowClick}
+      className={bodyRowClassName !== undefined ? clsx(BagFunctionUtil.resolve(bodyRowClassName, row.original)) : undefined}
+    />
   )
 
   const columnCount = Math.max(1, table.getVisibleLeafColumns().length)
-  const rowCount = containerRef.current && isUsingFillerRows ?
-    Math.floor(containerRef.current.clientHeight) / estimateRowHeight : 1
+  const rowCount = containerRef.current && isUsingFillerRows
+    ? Math.max(1, Math.floor(containerRef.current.clientHeight / estimateRowHeight))
+    : 1
 
   if (rows.length === 0) {
     return (
@@ -88,7 +120,7 @@ export const VirtualizedTableBody = ({
   if (!isMounted) {
     return (
       <tbody ref={bodyRef}>
-        {rows.map(row => renderRow(row, row.id, false))}
+        {rows.map(row => renderRow(row, false))}
       </tbody>
     )
   }
@@ -108,7 +140,7 @@ export const VirtualizedTableBody = ({
       {items.map(virtualRow => {
         const row = rows[virtualRow.index]
         if (!row) return null
-        return renderRow(row, virtualRow.key, true, virtualRow.index)
+        return renderRow(row, true, virtualRow.index)
       })}
       {paddingBottom > 0 && (
         <tr aria-hidden="true">

--- a/src/components/layout/table/useNaturalColumnWidthLock.ts
+++ b/src/components/layout/table/useNaturalColumnWidthLock.ts
@@ -14,7 +14,7 @@ export function useNaturalColumnWidthLock<T>({
   enabled,
 }: UseNaturalColumnWidthLockOptions<T>): boolean {
   const [isLocked, setIsLocked] = useState(false)
-  const autoLockedIdsRef = useRef<Set<string>>(new Set())
+  const autoLockedWidthsRef = useRef<Map<string, number>>(new Map())
 
   useLayoutEffect(() => {
     if (!enabled) {
@@ -43,7 +43,7 @@ export function useNaturalColumnWidthLock<T>({
       const width = headerCells[index]?.getBoundingClientRect().width
       if (width !== undefined && width > 0 && sizing[column.id] === undefined) {
         measured[column.id] = Math.round(width)
-        autoLockedIdsRef.current.add(column.id)
+        autoLockedWidthsRef.current.set(column.id, measured[column.id])
       }
     })
     if (Object.keys(measured).length === 0) return
@@ -57,13 +57,15 @@ export function useNaturalColumnWidthLock<T>({
       if (frame !== null) return
       frame = window.requestAnimationFrame(() => {
         frame = null
-        const autoLocked = autoLockedIdsRef.current
+        const autoLocked = autoLockedWidthsRef.current
         if (autoLocked.size === 0) return
-        autoLockedIdsRef.current = new Set()
+        autoLockedWidthsRef.current = new Map()
         setIsLocked(false)
         table.setColumnSizing(prev => {
           const next = { ...prev }
-          for (const id of autoLocked) delete next[id]
+          for (const [id, width] of autoLocked) {
+            if (next[id] === width) delete next[id]
+          }
           return next
         })
       })

--- a/src/components/layout/table/useNaturalColumnWidthLock.ts
+++ b/src/components/layout/table/useNaturalColumnWidthLock.ts
@@ -1,0 +1,79 @@
+import type { RefObject } from 'react'
+import { useLayoutEffect, useRef, useState } from 'react'
+import type { Table } from '@tanstack/react-table'
+
+export type UseNaturalColumnWidthLockOptions<T> = {
+  table: Table<T>,
+  tableRef: RefObject<HTMLTableElement | null>,
+  enabled: boolean,
+}
+
+export function useNaturalColumnWidthLock<T>({
+  table,
+  tableRef,
+  enabled,
+}: UseNaturalColumnWidthLockOptions<T>): boolean {
+  const [isLocked, setIsLocked] = useState(false)
+  const autoLockedIdsRef = useRef<Set<string>>(new Set())
+
+  useLayoutEffect(() => {
+    if (!enabled) {
+      setIsLocked(false)
+      return
+    }
+    const element = tableRef.current
+    if (!element) return
+
+    const columns = table.getVisibleLeafColumns()
+    const sizing = table.getState().columnSizing
+    const missing = columns.filter(column => sizing[column.id] === undefined)
+    if (missing.length === 0) {
+      setIsLocked(columns.length > 0)
+      return
+    }
+    setIsLocked(false)
+    if (table.getRowModel().rows.length === 0) return
+    if (element.getBoundingClientRect().width === 0) return
+    if (getComputedStyle(element).tableLayout !== 'auto') return
+
+    const headerCells = element.querySelectorAll<HTMLTableCellElement>('th[data-name="table-header-cell"]')
+    if (headerCells.length !== columns.length) return
+    const measured: Record<string, number> = {}
+    columns.forEach((column, index) => {
+      const width = headerCells[index]?.getBoundingClientRect().width
+      if (width !== undefined && width > 0 && sizing[column.id] === undefined) {
+        measured[column.id] = Math.round(width)
+        autoLockedIdsRef.current.add(column.id)
+      }
+    })
+    if (Object.keys(measured).length === 0) return
+    table.setColumnSizing(prev => ({ ...measured, ...prev }))
+  })
+
+  useLayoutEffect(() => {
+    if (!enabled || typeof window === 'undefined') return
+    let frame: number | null = null
+    const handleResize = () => {
+      if (frame !== null) return
+      frame = window.requestAnimationFrame(() => {
+        frame = null
+        const autoLocked = autoLockedIdsRef.current
+        if (autoLocked.size === 0) return
+        autoLockedIdsRef.current = new Set()
+        setIsLocked(false)
+        table.setColumnSizing(prev => {
+          const next = { ...prev }
+          for (const id of autoLocked) delete next[id]
+          return next
+        })
+      })
+    }
+    window.addEventListener('resize', handleResize)
+    return () => {
+      if (frame !== null) window.cancelAnimationFrame(frame)
+      window.removeEventListener('resize', handleResize)
+    }
+  }, [enabled, table])
+
+  return isLocked
+}

--- a/src/components/layout/virtualization/VirtualizedCardGrid.tsx
+++ b/src/components/layout/virtualization/VirtualizedCardGrid.tsx
@@ -1,5 +1,5 @@
-import type { ReactNode } from 'react'
-import { useEffect, useMemo, useRef, useState } from 'react'
+import type { CSSProperties, ReactNode } from 'react'
+import { memo, useEffect, useMemo, useRef, useState } from 'react'
 import clsx from 'clsx'
 import { columnsForWidth, chunkIntoRows, overscanRowsForBuffer } from './gridLayout'
 import { useVirtualizedRows } from './useVirtualizedRows'
@@ -12,6 +12,8 @@ const DEFAULT_ESTIMATE_ROW_HEIGHT_PX = 220
 const DEFAULT_OVERSCAN_ROWS = overscanRowsForBuffer(800, DEFAULT_ESTIMATE_ROW_HEIGHT_PX)
 const DEFAULT_VIRTUALIZE_THRESHOLD = 40
 const DEFAULT_REACH_BOTTOM_THRESHOLD_PX = 600
+
+const emptyRow: readonly unknown[] = []
 
 export type VirtualizedCardGridProps<T> = {
   items: readonly T[],
@@ -31,6 +33,44 @@ export type VirtualizedCardGridProps<T> = {
   onReachBottom?: () => void,
   reachBottomThresholdPx?: number,
 }
+
+type VirtualizedCardGridRowProps<T> = {
+  index: number,
+  translateY: number,
+  measureElement: (node: Element | null) => void,
+  rowStyle: CSSProperties,
+  items: readonly T[],
+  renderItem: (item: T) => ReactNode,
+}
+
+function VirtualizedCardGridRowBase<T>({
+  index,
+  translateY,
+  measureElement,
+  rowStyle,
+  items,
+  renderItem,
+}: VirtualizedCardGridRowProps<T>) {
+  return (
+    <div
+      data-index={index}
+      ref={measureElement}
+      style={{
+        position: 'absolute',
+        top: 0,
+        left: 0,
+        width: '100%',
+        transform: `translateY(${translateY}px)`,
+      }}
+    >
+      <div className="grid w-full" style={rowStyle}>
+        {items.map(renderItem)}
+      </div>
+    </div>
+  )
+}
+
+const VirtualizedCardGridRow = memo(VirtualizedCardGridRowBase) as typeof VirtualizedCardGridRowBase
 
 /**
  * A responsive, virtualized grid of cards backed by TanStack Virtual. Shares its
@@ -97,6 +137,11 @@ export function VirtualizedCardGrid<T>({
   }, [columns, virtualizer])
 
   const autoFillTemplate = `repeat(auto-fill, minmax(min(100%, ${minCardWidthPx}px), 1fr))`
+  const virtualizedRowStyle = useMemo((): CSSProperties => ({
+    gridTemplateColumns: `repeat(${columns}, minmax(0, 1fr))`,
+    gap: gapPx,
+    paddingBottom: gapPx,
+  }), [columns, gapPx])
   const shouldVirtualize = isMounted && items.length > virtualizeThreshold
 
   if (!shouldVirtualize) {
@@ -109,35 +154,20 @@ export function VirtualizedCardGrid<T>({
     )
   }
 
-  const explicitTemplate = `repeat(${columns}, minmax(0, 1fr))`
-
   return (
     <div ref={containerRef} className={clsx('w-full print:hidden', containerClassName)}>
       <div style={{ height: virtualizer.getTotalSize(), width: '100%', position: 'relative' }}>
-        {virtualizer.getVirtualItems().map((virtualRow) => {
-          const row = rows[virtualRow.index] ?? []
-          return (
-            <div
-              key={virtualRow.key}
-              data-index={virtualRow.index}
-              ref={virtualizer.measureElement}
-              style={{
-                position: 'absolute',
-                top: 0,
-                left: 0,
-                width: '100%',
-                transform: `translateY(${virtualRow.start - offset}px)`,
-              }}
-            >
-              <div
-                className="grid w-full"
-                style={{ gridTemplateColumns: explicitTemplate, gap: gapPx, paddingBottom: gapPx }}
-              >
-                {row.map(renderItem)}
-              </div>
-            </div>
-          )
-        })}
+        {virtualizer.getVirtualItems().map((virtualRow) => (
+          <VirtualizedCardGridRow
+            key={virtualRow.key}
+            index={virtualRow.index}
+            translateY={virtualRow.start - offset}
+            measureElement={virtualizer.measureElement}
+            rowStyle={virtualizedRowStyle}
+            items={(rows[virtualRow.index] ?? emptyRow) as readonly T[]}
+            renderItem={renderItem}
+          />
+        ))}
       </div>
     </div>
   )

--- a/src/components/layout/virtualization/useVirtualizedRows.ts
+++ b/src/components/layout/virtualization/useVirtualizedRows.ts
@@ -2,12 +2,7 @@ import type { Key, RefObject } from 'react'
 import { useEffect, useState } from 'react'
 import type { Virtualizer } from '@tanstack/react-virtual'
 import { useVirtualizer, useWindowVirtualizer } from '@tanstack/react-virtual'
-import {
-  findPageScrollContainer,
-  getScrollMetrics,
-  isNearBottom,
-  type VirtualizationScroll
-} from './virtualizationScroll'
+import { findPageScrollContainer, type VirtualizationScroll } from './virtualizationScroll'
 
 export type UseVirtualizedRowsOptions = {
   scroll: VirtualizationScroll,
@@ -24,7 +19,7 @@ export type UseVirtualizedRowsOptions = {
   contentRef: RefObject<HTMLElement | null>,
   /** The scroll container element for the `'container'` mode. */
   containerRef?: RefObject<HTMLElement | null>,
-  /** Called while the user is within `reachBottomThresholdPx` of the bottom. */
+  /** Called while the rendered range is within `reachBottomThresholdPx` of the end. */
   onReachBottom?: () => void,
   reachBottomThresholdPx?: number,
 }
@@ -99,14 +94,29 @@ export function useVirtualizedRows({
   }, [scroll, usesOuterScroll, contentRef, count])
 
   const common = {
-    count,
     estimateSize: () => estimateRowHeight,
     overscan,
     ...(getItemKey ? { getItemKey } : {}),
   }
-  const windowVirtualizer = useWindowVirtualizer({ ...common, scrollMargin, enabled: enabled && scroll === 'window' })
-  const containerVirtualizer = useVirtualizer({ ...common, getScrollElement: () => containerRef?.current ?? null, enabled: enabled && scroll === 'container' })
-  const pageVirtualizer = useVirtualizer({ ...common, getScrollElement: () => pageScrollElement, scrollMargin, enabled: enabled && scroll === 'page' })
+  const windowVirtualizer = useWindowVirtualizer({
+    ...common,
+    count: scroll === 'window' ? count : 0,
+    scrollMargin,
+    enabled: enabled && scroll === 'window',
+  })
+  const containerVirtualizer = useVirtualizer({
+    ...common,
+    count: scroll === 'container' ? count : 0,
+    getScrollElement: () => containerRef?.current ?? null,
+    enabled: enabled && scroll === 'container',
+  })
+  const pageVirtualizer = useVirtualizer({
+    ...common,
+    count: scroll === 'page' ? count : 0,
+    getScrollElement: () => pageScrollElement,
+    scrollMargin,
+    enabled: enabled && scroll === 'page',
+  })
 
   const virtualizer = (
     scroll === 'window'
@@ -117,24 +127,12 @@ export function useVirtualizedRows({
   ) as unknown as Virtualizer<Element, Element>
   const offset = usesOuterScroll ? scrollMargin : 0
 
-  // Infinite scroll: notify the consumer when the active scroll target nears its bottom.
+  const endIndex = virtualizer.range?.endIndex ?? (enabled ? -1 : (isMounted ? count - 1 : -1))
+  const thresholdRows = Math.max(1, Math.ceil(reachBottomThresholdPx / Math.max(1, estimateRowHeight)))
   useEffect(() => {
-    if (!onReachBottom || typeof window === 'undefined') return
-    const target: HTMLElement | Window | null =
-      scroll === 'window' ? window : scroll === 'page' ? pageScrollElement : containerRef?.current ?? null
-    if (!target) return
-
-    const handler = () => {
-      if (isNearBottom(getScrollMetrics(target), reachBottomThresholdPx)) onReachBottom()
-    }
-    target.addEventListener('scroll', handler, { passive: true } as AddEventListenerOptions)
-    window.addEventListener('resize', handler)
-    handler()
-    return () => {
-      target.removeEventListener('scroll', handler)
-      window.removeEventListener('resize', handler)
-    }
-  }, [scroll, pageScrollElement, containerRef, onReachBottom, reachBottomThresholdPx, isMounted])
+    if (!onReachBottom) return
+    if (endIndex >= count - 1 - thresholdRows) onReachBottom()
+  }, [onReachBottom, endIndex, count, thresholdRows, isMounted])
 
   return { virtualizer, offset, pageScrollElement, isMounted }
 }

--- a/src/components/layout/virtualization/useVirtualizedRows.ts
+++ b/src/components/layout/virtualization/useVirtualizedRows.ts
@@ -96,6 +96,8 @@ export function useVirtualizedRows({
   const common = {
     estimateSize: () => estimateRowHeight,
     overscan,
+    useScrollendEvent: true,
+    useAnimationFrameWithResizeObserver: true,
     ...(getItemKey ? { getItemKey } : {}),
   }
   const windowVirtualizer = useWindowVirtualizer({

--- a/src/style/theme/components/app-page.css
+++ b/src/style/theme/components/app-page.css
@@ -79,8 +79,12 @@
     @apply flex-col-0 px-3 pt-2;
   }
 
+  [data-name="app-page-body"] {
+    @apply flex-col-0 grow min-w-0 h-full overflow-hidden;
+  }
+
   [data-name="app-page-content"] {
-    @apply flex-col-0 grow overflow-y-auto overscroll-y-contain;
+    @apply flex-col-0 grow min-h-0 overflow-y-auto overscroll-y-contain;
     scrollbar-gutter: stable;
 
     &[data-no-scrolling] {
@@ -89,7 +93,7 @@
   }
 
   [data-name="app-page-header"] {
-    @apply sticky top-0 right-0 z-20 flex-row-2 items-center p-4 bg-background text-on-background;
+    @apply flex-row-2 items-center p-4 bg-background text-on-background;
 
     @variant desktop {
       @apply pl-6;

--- a/src/style/theme/components/table.css
+++ b/src/style/theme/components/table.css
@@ -14,6 +14,10 @@
     &[data-scrollbar="both"] {
       --table-rounding-right: 0px;
     }
+
+    &[data-page-scroll] {
+      @apply overflow-visible w-fit min-w-full;
+    }
   }
 
   [data-name="table"] {
@@ -22,16 +26,10 @@
 
     &[data-column-sizing="natural"] {
       @apply table-auto w-full;
-    }
-  }
 
-  [data-name="table-header"] {
-    &[data-sticky-page] {
-      @apply relative z-10;
-    }
-
-    @media print {
-      transform: none !important;
+      &[data-natural-locked] {
+        @apply table-fixed;
+      }
     }
   }
 

--- a/src/style/theme/components/table.css
+++ b/src/style/theme/components/table.css
@@ -81,6 +81,7 @@
     @apply absolute right-1 top-1/2 -translate-y-1/2;
     @apply h-6 w-2 rounded bg-primary;
     @apply cursor-col-resize;
+    @apply select-none touch-none;
     @apply opacity-0 transition-opacity;
 
     &[data-active] {

--- a/tests/virtualization/gridLayout.test.ts
+++ b/tests/virtualization/gridLayout.test.ts
@@ -1,0 +1,57 @@
+
+import { chunkIntoRows, columnsForWidth, overscanRowsForBuffer } from '../../src/components/layout/virtualization/gridLayout'
+
+describe('columnsForWidth', () => {
+  it('returns at least one column for any positive width', () => {
+    expect(columnsForWidth(100, 384, 12)).toBe(1)
+    expect(columnsForWidth(384, 384, 12)).toBe(1)
+  })
+
+  it('fits as many minmax columns as the width allows, accounting for the gap', () => {
+    expect(columnsForWidth(792, 384, 12)).toBe(2)
+    expect(columnsForWidth(1200, 384, 12)).toBe(3)
+    expect(columnsForWidth(1188, 384, 12)).toBe(3)
+  })
+
+  it('falls back to a single column for invalid widths', () => {
+    expect(columnsForWidth(0, 384, 12)).toBe(1)
+    expect(columnsForWidth(-50, 384, 12)).toBe(1)
+    expect(columnsForWidth(Number.NaN, 384, 12)).toBe(1)
+  })
+})
+
+describe('chunkIntoRows', () => {
+  it('splits items into rows of the requested column count', () => {
+    expect(chunkIntoRows([1, 2, 3, 4, 5], 2)).toEqual([[1, 2], [3, 4], [5]])
+  })
+
+  it('keeps a single row when columns exceed item count', () => {
+    expect(chunkIntoRows([1, 2], 5)).toEqual([[1, 2]])
+  })
+
+  it('returns no rows for an empty list', () => {
+    expect(chunkIntoRows([], 3)).toEqual([])
+  })
+
+  it('treats non-positive column counts as a single column', () => {
+    expect(chunkIntoRows([1, 2, 3], 0)).toEqual([[1], [2], [3]])
+  })
+})
+
+describe('overscanRowsForBuffer', () => {
+  it('renders enough rows to cover the pixel buffer ahead of the viewport', () => {
+    expect(overscanRowsForBuffer(600, 56)).toBe(11)
+    expect(overscanRowsForBuffer(600, 220)).toBe(6)
+  })
+
+  it('never drops below the minimum overscan', () => {
+    expect(overscanRowsForBuffer(50, 56)).toBe(6)
+    expect(overscanRowsForBuffer(600, 56, 20)).toBe(20)
+  })
+
+  it('falls back to the minimum for invalid inputs', () => {
+    expect(overscanRowsForBuffer(0, 56)).toBe(6)
+    expect(overscanRowsForBuffer(600, 0)).toBe(6)
+    expect(overscanRowsForBuffer(Number.NaN, 56)).toBe(6)
+  })
+})


### PR DESCRIPTION
Releases **0.13.5**. Fixes the laggy virtualized infinite scroll and the slow/jittery sticky header on the tasks patients & tasks lists by removing all per-scroll JavaScript work.

## Sticky header: pure CSS instead of JS

The page-mode sticky header was repositioned by a scroll listener doing four forced layout reads (`getBoundingClientRect` × 3 + `offsetHeight`) and a `transform` write on every scroll event. Because it runs on the main thread, the header visibly trailed the scroll whenever React was busy rendering virtualized rows.

It is now plain `position: sticky` (compositor-driven, no main-thread work, sticks instantly):

- The `AppPage` header moved out of the scroll container (new `app-page-body` wrapper around header + `app-page-content`), so sticky `th` cells stick at `top: 0` of the content scroller with no offset math.
- Page/window-scroll table containers no longer create their own scrollport (`overflow: visible; width: fit-content; min-width: 100%`), so sticky reaches the page scroller. Wide tables pan via the page scroll container, whose horizontal scrollbar is actually reachable (before, it sat at the bottom of the full-height table container).
- The `stickyScroll` prop on `TableHeader`, the transform CSS hooks, and the JS effect are removed.

## Virtualized scroll performance

- **Memoized rows**: TanStack Virtual re-renders the body on every scroll frame. Table rows and card-grid rows are now `memo` components with scroll-stable props, so those re-renders only reconcile the row list instead of re-rendering every visible cell (chips, tooltips, progress indicators, property editors).
- **Locked natural column widths**: with `columnSizingMode: 'natural'` (`table-auto`), every virtual row swap re-ran the full-table intrinsic width negotiation — the column/header shifting ("recalculating") and a large layout cost per scroll. `useNaturalColumnWidthLock` measures the rendered header widths once rows exist, writes them into `columnSizing`, and flips the table to fixed layout (`data-natural-locked`), making row swaps row-local layout work. Widths re-measure on viewport resize; user-resized columns keep their width.
- **Infinite scroll without scroll listeners**: `onReachBottom` derives from the virtualizer's rendered range instead of a scroll listener reading `scrollHeight`/`clientHeight` (forced layout) on every scroll event.

## Memory

- Inactive virtualizer instances (two of the three scroll modes are always unused) get a zero item count, so they no longer hold measurement caches sized to the full row set.
- Memoized rows eliminate the per-frame React element allocations for all visible cells; removing the scroll/resize listeners (sticky JS, reach-bottom, page-mode scrollbar observer) drops the per-table observer count.

## Library usage

`@tanstack/react-virtual` (~3 kB gzipped, tree-shaken core) stays: it handles dynamic row measurement, scroll-margin bookkeeping, and range extraction that a hand-rolled windowing hook would re-implement with more code and more risk. The grid layout helper tests moved here from the tasks app, which now consumes `overscanRowsForBuffer` from this package instead of a duplicated copy.

## Verification

- `npm run lint`, `npm test` (107 tests), `npm run build` — green
- Full tasks e2e suite ran against this build (23 tests incl. sticky-header position, whole-page scrolling, infinite scroll to 77 rows without duplicates, printing, natural sizing) — green

Companion PR: helpwave/tasks (adopts 0.13.5). Publishing 0.13.5 (on merge via the publish workflow) is required before the tasks PR's `npm ci` can resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cxr8hJSssmzPRQNngm4uqy

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cxr8hJSssmzPRQNngm4uqy)_