### PR TITLE
fix: keep horizontal table scrolling inside the table container in page-scroll mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Table containers in page-scroll mode (`data-page-scroll`) no longer grow beyond 100% width; horizontal overflow now scrolls inside the table container instead of the surrounding page, while vertical scrolling stays on the page
+
 ## [0.14.0] - 2026-07-05
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.13.6] - 2026-07-05
+
+### Changed
+
+- `browserslist` now explicitly targets desktop Safari and older Apple browsers (`Safari >= 11`, `iOS >= 11`) so autoprefixer emits the required `-webkit-` prefixes in the published CSS
 
 ### Fixed
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@helpwave/hightide",
-  "version": "0.14.0",
+  "version": "0.13.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@helpwave/hightide",
-      "version": "0.14.0",
+      "version": "0.13.6",
       "license": "MPL-2.0",
       "dependencies": {
         "@helpwave/internationalization": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -10,13 +10,14 @@
     "access": "public"
   },
   "license": "MPL-2.0",
-  "version": "0.14.0",
+  "version": "0.13.6",
   "browserslist": [
     "> 0.2%",
     "last 3 versions",
     "Firefox ESR",
     "not dead",
-    "iOS >= 12",
+    "Safari >= 11",
+    "iOS >= 11",
     "Android >= 5"
   ],
   "files": [

--- a/src/style/theme/components/table.css
+++ b/src/style/theme/components/table.css
@@ -16,7 +16,7 @@
     }
 
     &[data-page-scroll] {
-      @apply overflow-visible w-fit min-w-full;
+      @apply overflow-x-auto w-full max-w-full;
     }
   }
 


### PR DESCRIPTION
## Summary

The `data-page-scroll` table container variant sized itself to the table's natural width (`w-fit min-w-full`, `overflow: visible`), so wide tables grew past 100% width and made the surrounding page content scroll horizontally.

The container now stays at `w-full max-w-full` with `overflow-x: auto`, so horizontal overflow scrolls inside the table container itself.

Vertical scrolling is untouched: the container has no height cap, so it never scrolls vertically and the page scroll container (`app-page-content`) keeps driving vertical scrolling. Page-mode row virtualization is unaffected because it resolves its scroll element via the `app-page-content` selector, not via overflow inspection.

## Verification

- `npm run build-css` — compiled rule is `[data-name="table-container"][data-page-scroll]{width:100%;max-width:100%;overflow-x:auto}`
- `npm test` — 16 suites, 165 tests pass
- Rendered the compiled CSS with the real AppPage/table DOM structure in Chromium (1280px viewport, 12 columns × 200px min-width): container stays at 100% width, page no longer scrolls horizontally, horizontal scrolling works inside the container, and vertical scrolling still happens on the page scroll container

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PnM1fiefZuHWF6z3sdmXGw

---
_Generated by [Claude Code](https://claude.ai/code/session_01PnM1fiefZuHWF6z3sdmXGw)_